### PR TITLE
fixed error in artifact classification

### DIFF
--- a/tests/tests_ecg.py
+++ b/tests/tests_ecg.py
@@ -78,7 +78,7 @@ def test_ecg_peaks():
                                  method="neurokit")
 
     assert signals.shape == (120000, 1)
-    assert np.allclose(signals["ECG_R_Peaks"].values.sum(dtype=np.int64), 142,
+    assert np.allclose(signals["ECG_R_Peaks"].values.sum(dtype=np.int64), 150,
                        atol=1)
 
 


### PR DESCRIPTION
Fixed small but critical error in `ecg_fixpeaks()`. The fix is swapping the conditionals on line 201 and 209 (the other changes are mostly cosmetic). Also adapted one test that was affected by the change.