### PR TITLE
fixing random seeds

### DIFF
--- a/tests/tests_rsp.py
+++ b/tests/tests_rsp.py
@@ -5,20 +5,21 @@ import matplotlib.pyplot as plt
 
 import biosppy
 
-np.random.seed(42)
-
 def test_rsp_simulate():
-    rsp1 = nk.rsp_simulate(duration=20, length=3000)
+    rsp1 = nk.rsp_simulate(duration=20, length=3000, random_state=42)
     assert len(rsp1) == 3000
 
-    rsp2 = nk.rsp_simulate(duration=20, length=3000, respiratory_rate=80)
+    rsp2 = nk.rsp_simulate(duration=20, length=3000, respiratory_rate=80,
+                           random_state=42)
 #    pd.DataFrame({"RSP1":rsp1, "RSP2":rsp2}).plot()
 #    pd.DataFrame({"RSP1":rsp1, "RSP2":rsp2}).hist()
     assert (len(nk.signal_findpeaks(rsp1, height_min=0.2)["Peaks"]) <
             len(nk.signal_findpeaks(rsp2, height_min=0.2)["Peaks"]))
 
-    rsp3 = nk.rsp_simulate(duration=20, length=3000, method="sinusoidal")
-    rsp4 = nk.rsp_simulate(duration=20, length=3000, method="breathmetrics")
+    rsp3 = nk.rsp_simulate(duration=20, length=3000, method="sinusoidal",
+                           random_state=42)
+    rsp4 = nk.rsp_simulate(duration=20, length=3000, method="breathmetrics",
+                           random_state=42)
 #    pd.DataFrame({"RSP3":rsp3, "RSP4":rsp4}).plot()
     assert (len(nk.signal_findpeaks(rsp3, height_min=0.2)["Peaks"]) >
             len(nk.signal_findpeaks(rsp4, height_min=0.2)["Peaks"]))


### PR DESCRIPTION
the signals in `test_rsp_simulated()` were generated with a new seed on every run since the seed was not passed on to `rsp_simulate()`.