### PR TITLE
Pre-compute means in _ecg_findpeaks_MWA

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,6 +30,7 @@ Contributors
 * `@renatosc <https://github.com/renatosc>`_
 * `Nicolas Beaudoin-Gagnon <https://github.com/Fegalf>`_ *(Université Laval, Canada)*
 * `@rubinovitz <https://github.com/rubinovitz>`_
+* `@purpl3F0x (Stavros Avramidis) <https://github.com/purpl3F0x>`_
 * `You? <https://neurokit2.readthedocs.io/en/latest/contributing.html>`_
 
 More details `here <https://github.com/neuropsychology/NeuroKit/graphs/contributors>`_.

--- a/neurokit2/ecg/ecg_findpeaks.py
+++ b/neurokit2/ecg/ecg_findpeaks.py
@@ -823,12 +823,22 @@ def _ecg_findpeaks_MWA(signal, window_size):
     """
     From https://github.com/berndporr/py-ecg-detectors/
     """
+
     mwa = np.zeros(len(signal))
+    sums = np.cumsum(signal)
+
+    def get_mean(begin, end):
+        if begin == 0:
+            return sums[end - 1] / end
+
+        dif = sums[end - 1] - sums[begin - 1]
+        return dif / (end - begin)
+
     for i in range(len(signal)):
         if i < window_size:
             section = signal[0:i]
         else:
-            section = signal[i-window_size:i]
+            section = get_mean(i - window_size, i)
 
         if i != 0:
             mwa[i] = np.mean(section)
@@ -836,7 +846,6 @@ def _ecg_findpeaks_MWA(signal, window_size):
             mwa[i] = signal[i]
 
     return mwa
-
 
 
 


### PR DESCRIPTION
# Description

Uses a (inclusive )scan to precompute the individual means of the signal. Instead of computing the a mean every time(Yields about x10 performance.)

# Proposed Changes

I changed the `_ecg_findpeaks_MWA `  in  `neurokit2/ecg/ecg_findpeaks.py`
