### PR TITLE
Changes to Welch method in signal_psd()

### DIFF
--- a/neurokit2/ecg/ecg_hrv.py
+++ b/neurokit2/ecg/ecg_hrv.py
@@ -155,7 +155,7 @@ def _ecg_hrv_time(rri):
 
 
 def _ecg_hrv_frequency(ecg_period, sampling_rate=1000, ulf=(0, 0.0033), vlf=(0.0033, 0.04), lf=(0.04, 0.15), hf=(0.15, 0.4), vhf=(0.4, 0.5), method="welch", show=False):
-    power = signal_power(ecg_period, frequency_band=[ulf, vlf, lf, hf, vhf], sampling_rate=sampling_rate, method=method, max_frequency=0.5, resolution=0.3, show=show)
+    power = signal_power(ecg_period, frequency_band=[ulf, vlf, lf, hf, vhf], sampling_rate=sampling_rate, method=method, max_frequency=0.5, show=show)
     power.columns = ["ULF", "VLF", "LF", "HF", "VHF"]
     out = power.to_dict(orient="index")[0]
 

--- a/neurokit2/ecg/ecg_hrv.py
+++ b/neurokit2/ecg/ecg_hrv.py
@@ -155,7 +155,7 @@ def _ecg_hrv_time(rri):
 
 
 def _ecg_hrv_frequency(ecg_period, sampling_rate=1000, ulf=(0, 0.0033), vlf=(0.0033, 0.04), lf=(0.04, 0.15), hf=(0.15, 0.4), vhf=(0.4, 0.5), method="welch", show=False):
-    power = signal_power(ecg_period, frequency_band=[ulf, vlf, lf, hf, vhf], sampling_rate=sampling_rate, method=method, max_frequency=0.5, show=show)
+    power = signal_power(ecg_period, frequency_band=[ulf, vlf, lf, hf, vhf], sampling_rate=sampling_rate, method=method, max_frequency=0.5, resolution=0.3, show=show)
     power.columns = ["ULF", "VLF", "LF", "HF", "VHF"]
     out = power.to_dict(orient="index")[0]
 

--- a/neurokit2/rsp/rsp_rrv.py
+++ b/neurokit2/rsp/rsp_rrv.py
@@ -73,7 +73,7 @@ def rsp_rrv(rsp_rate, peaks=None, sampling_rate=1000, show=False):
 
     # Get raw and interpolated R-R intervals
     bbi = np.diff(peaks) / sampling_rate * 1000
-    rsp_period = rsp_rate / 60 * sampling_rate
+    rsp_period = 60 * sampling_rate/ rsp_rate
 
     # Get indices
     rrv = {}  # Initialize empty dict
@@ -130,7 +130,7 @@ def _rsp_rrv_time(bbi):
 
 
 def _rsp_rrv_frequency(rsp_period, vlf=(0, 0.04), lf=(0.04, 0.15), hf=(0.15, 0.4), method="welch"):
-    power = signal_power(rsp_period, frequency_band=[vlf, lf, hf], sampling_rate=1000, method=method, max_frequency=0.5)
+    power = signal_power(rsp_period, frequency_band=[vlf, lf, hf], sampling_rate=1000, method=method, max_frequency=0.5, resolution=0.5)
     power.columns = ["VLF", "LF", "HF"]
     out = power.to_dict(orient="index")[0]
 

--- a/neurokit2/rsp/rsp_rrv.py
+++ b/neurokit2/rsp/rsp_rrv.py
@@ -78,7 +78,7 @@ def rsp_rrv(rsp_rate, peaks=None, sampling_rate=1000, show=False):
     # Get indices
     rrv = {}  # Initialize empty dict
     rrv.update(_rsp_rrv_time(bbi))
-    rrv.update(_rsp_rrv_frequency(rsp_period))
+    rrv.update(_rsp_rrv_frequency(rsp_period, show=show))
     rrv.update(_rsp_rrv_nonlinear(bbi, rsp_period))
 
     rrv = pd.DataFrame.from_dict(rrv, orient='index').T.add_prefix("RRV_")
@@ -129,8 +129,8 @@ def _rsp_rrv_time(bbi):
 
 
 
-def _rsp_rrv_frequency(rsp_period, vlf=(0, 0.04), lf=(0.04, 0.15), hf=(0.15, 0.4), method="welch"):
-    power = signal_power(rsp_period, frequency_band=[vlf, lf, hf], sampling_rate=1000, method=method, max_frequency=0.5, resolution=0.5)
+def _rsp_rrv_frequency(rsp_period, vlf=(0, 0.04), lf=(0.04, 0.15), hf=(0.15, 0.4), method="welch", show=False):
+    power = signal_power(rsp_period, frequency_band=[vlf, lf, hf], sampling_rate=1000, method=method, max_frequency=0.5, show=show)
     power.columns = ["VLF", "LF", "HF"]
     out = power.to_dict(orient="index")[0]
 

--- a/neurokit2/signal/signal_power.py
+++ b/neurokit2/signal/signal_power.py
@@ -126,7 +126,7 @@ def _signal_power_instant_plot(psd, out, frequency_band):
         ax.fill_between(psd["Frequency"][band_index], 0, psd["Power"][band_index], label=label)
     ax.legend()
 
-    ax.set(xlabel="Frequency (Hz)", ylabel="Spectrum")
+    ax.set(xlabel="Frequency (Hz)", ylabel="Spectrum (ms2/Hz)")
     return ax
 
 # =============================================================================

--- a/neurokit2/signal/signal_psd.py
+++ b/neurokit2/signal/signal_psd.py
@@ -4,7 +4,7 @@ import pandas as pd
 import scipy.signal
 
 
-def signal_psd(signal, sampling_rate=1000, method="multitapers", show=True, min_frequency=0, max_frequency=np.inf, window=None, resolution=0.5, precision=2**12):
+def signal_psd(signal, sampling_rate=1000, method="multitapers", show=True, min_frequency=0, max_frequency=np.inf, window=None):
     """Compute the Power Spectral Density (PSD).
 
     Parameters
@@ -87,7 +87,6 @@ def signal_psd(signal, sampling_rate=1000, method="multitapers", show=True, min_
         if nperseg > len(signal) / 2:
             print("Neurokit warning: signal_psd(): The duration of recording is too short to support a sufficiently long window for high frequency resolution. Consider using a longer recording or increasing the `min_frequency`")
             nperseg = int(len(signal / 2))
-            nperseg = nperseg * resolution
 
         frequency, power = scipy.signal.welch(signal,
                                               fs=sampling_rate,


### PR DESCRIPTION
# Proposed Changes

To determine the window_length, the following steps were made:

## Prioritize frequency resolution
A nperseg long enough to capture at least 2 cycles of lowest frequency:
```
# Define window length
        if min_frequency == 0:
            min_frequency = 0.001  # sanitize lowest frequency
        if window is not None:
            nperseg = int(window * sampling_rate)
        else:
            # to capture at least 2  cycles of min_frequency
            nperseg = int((2 / min_frequency) * sampling_rate)
```

However, since our signals are mostly sampled at high frequency (1000-4000Hz) and min_frequency is often very low (~0 Hz 😅 ), nperseg can be super huge, sometimes longer than duration of signal. 
 
## Sacrifice frequency resolution for more appropriate window length

```
# in case duration of recording is not sufficient
        if nperseg > len(signal) / 2:
            print("Neurokit warning: signal_psd(): The duration of recording is too short to support a sufficiently long window for high frequency resolution. Consider using a longer recording or increasing the `min_frequency`")
            nperseg = int(len(signal / 2))
            nperseg = nperseg * resolution
```
Here, an argument resolution is used to further adjust the nperseg. In cases where nperseg is still too large and temporal resolution is jeopardized (too many variances captured, often seen in very sharpy, pointy power plot), users can choose to cut nperseg further by decreasing the resolution (frequency resolution). 

For example, using an ecg_signal of 4 minutes, sampling_rate=4000Hz and min_frequency=0Hz, at default resolution of 0.5:
![image](https://user-images.githubusercontent.com/47100701/79533419-64abd580-80aa-11ea-850e-fe6acedb615f.png)

and cut the resolution to 0.3: 
![image](https://user-images.githubusercontent.com/47100701/79533442-755c4b80-80aa-11ea-9f76-b7a2898f8d20.png)

The balance is very much depending on the user's decision.
P/S: the Power axis is now not logged, current unit is (ms^2/Hz), which is a rather common unit. Other scales that are common are (s^2/Hz) or decibels (dB = 10 * log10(power)). We can pick one or let the user decides 😃 