### PR TITLE
Fixed typo in eda notebook.

### DIFF
--- a/docs/examples/eda.ipynb
+++ b/docs/examples/eda.ipynb
@@ -38,7 +38,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Extract the cleaned ECG signal"
+    "## Extract the cleaned EDA signal"
    ]
   },
   {
@@ -274,7 +274,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Proposed Changes 

I changed `Extract the cleaned ECG signal` to `Extract the cleaned EDA signal` in the `Analyze EDA Notebook` because this notebook deals with EDA signals, not ECG. This was a small typo, but can be misleading when trying to follow the tutorial.


