### PR TITLE
Fixed potential bug in hrv_nonlinear.py

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,6 +24,7 @@ Contributors
 * `Stavros Avramidis <https://github.com/purpl3F0x>`_
 * `Tiago Rodrigues <https://github.com/TiagoTostas>`_ *(IST, Lisbon)*
 * `Mitchell Bishop <https://github.com/Mitchellb16>`_ *(NINDS, USA)*
+* `Robert Richer <https://github.com/richrobe>`_ *(FAU Erlangen-Nürnberg, Germany)*
 
 
 Thanks also to `Gansheng Tan <https://github.com/GanshengT>`_, `Chuan-Peng Hu <https://github.com/hcp4715>`_, `@ucohen <https://github.com/ucohen>`_, `Anthony Gatti <https://github.com/gattia>`_, `Julien Lamour <https://github.com/lamourj>`_, `@renatosc <https://github.com/renatosc>`_, `Nicolas Beaudoin-Gagnon <https://github.com/Fegalf>`_ and `@rubinovitz <https://github.com/rubinovitz>`_ for their contribution in `NeuroKit 1 <https://github.com/neuropsychology/NeuroKit.py>`_.

--- a/neurokit2/hrv/hrv_nonlinear.py
+++ b/neurokit2/hrv/hrv_nonlinear.py
@@ -81,9 +81,10 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False):
     out = {}  # Initialize empty container for results
 
     # Poincaré
+    sd_rri = np.std(rri, ddof=1) ** 2
     sd_heart_period = np.std(diff_rri, ddof=1) ** 2
     out["SD1"] = np.sqrt(sd_heart_period * 0.5)
-    out["SD2"] = np.sqrt(2 * sd_heart_period - 0.5 * sd_heart_period)
+    out["SD2"] = np.sqrt(2 * sd_rri - 0.5 * sd_heart_period)
     out["SD2SD1"] = out["SD2"] / out["SD1"]
 
     # CSI / CVI


### PR DESCRIPTION
# Description

This PR aims at fixing a potential bug in the computation of non-linear HRV features (hrv_nonlinear.py)

According to Brennan et al. 2001 (https://doi.org/10.1109/10.959330, Eq. 12) SD2 is computed as: sqrt(2 * std(RR)^2 - 0.5 * std(SD)),
where RR = RR intervals, SD = successive differences

In the code, SD2 is computed as: sqrt(2 * std(SD)^2 - 0.5 * std(SD))

# Proposed Changes

I changed the `hrv_nonlinear()` function so that SD2 (and SD2/SD1, accordingly) is computed correctly.


# Checklist

Here are some things to check before creating the PR.

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.