### PR TITLE
[fix] hrv_nonlinear: changed SD2/SD1 ratio of Poincaré to SD1/SD2

### DIFF
--- a/neurokit2/hrv/hrv_nonlinear.py
+++ b/neurokit2/hrv/hrv_nonlinear.py
@@ -65,7 +65,7 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False):
 
     References
     ----------
-    - Brennan, M. et al. (2001). Do Existing Measures of Poincaré Plot Geometry Reflect Nonlinear 
+    - Brennan, M. et al. (2001). Do Existing Measures of Poincaré Plot Geometry Reflect Nonlinear
     Features of Heart Rate Variability?. IEEE Transactions on Biomedical Engineering, 48(11), 1342-1347.
     - Stein, P. K. (2002). Assessing heart rate variability from real-world Holter reports. Cardiac
     electrophysiology review, 6(3), 239-244.

--- a/neurokit2/hrv/hrv_nonlinear.py
+++ b/neurokit2/hrv/hrv_nonlinear.py
@@ -65,6 +65,8 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False):
 
     References
     ----------
+    - Brennan, M. et al. (2001). Do Existing Measures of Poincaré Plot Geometry Reflect Nonlinear Features of Heart Rate Variability?.
+    IEEE Transactions on Biomedical Engineering, 48(11), 1342-1347.
     - Stein, P. K. (2002). Assessing heart rate variability from real-world Holter reports. Cardiac
     electrophysiology review, 6(3), 239-244.
     - Shaffer, F., & Ginsberg, J. P. (2017). An overview of heart rate variability metrics and norms.
@@ -85,7 +87,7 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False):
     sd_heart_period = np.std(diff_rri, ddof=1) ** 2
     out["SD1"] = np.sqrt(sd_heart_period * 0.5)
     out["SD2"] = np.sqrt(2 * sd_rri - 0.5 * sd_heart_period)
-    out["SD2SD1"] = out["SD2"] / out["SD1"]
+    out["SD1SD2"] = out["SD1"] / out["SD2"]
 
     # CSI / CVI
     T = 4 * out["SD1"]

--- a/neurokit2/hrv/hrv_nonlinear.py
+++ b/neurokit2/hrv/hrv_nonlinear.py
@@ -65,8 +65,8 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False):
 
     References
     ----------
-    - Brennan, M. et al. (2001). Do Existing Measures of Poincaré Plot Geometry Reflect Nonlinear Features of Heart Rate Variability?.
-    IEEE Transactions on Biomedical Engineering, 48(11), 1342-1347.
+    - Brennan, M. et al. (2001). Do Existing Measures of Poincaré Plot Geometry Reflect Nonlinear 
+    Features of Heart Rate Variability?. IEEE Transactions on Biomedical Engineering, 48(11), 1342-1347.
     - Stein, P. K. (2002). Assessing heart rate variability from real-world Holter reports. Cardiac
     electrophysiology review, 6(3), 239-244.
     - Shaffer, F., & Ginsberg, J. P. (2017). An overview of heart rate variability metrics and norms.

--- a/tests/tests_ecg.py
+++ b/tests/tests_ecg.py
@@ -247,7 +247,7 @@ def test_ecg_intervalrelated():
                'HRV_CVNN', 'HRV_CVSD', 'HRV_MedianNN', 'HRV_MadNN', 'HRV_MCVNN',
                'HRV_pNN50', 'HRV_pNN20', 'HRV_TINN', 'HRV_HTI', 'HRV_ULF',
                'HRV_VLF', 'HRV_LF', 'HRV_HF', 'HRV_VHF', 'HRV_LFHF', 'HRV_LFn',
-               'HRV_HFn', 'HRV_LnHF', 'HRV_SD1', 'HRV_SD2', 'HRV_SD2SD1',
+               'HRV_HFn', 'HRV_LnHF', 'HRV_SD1', 'HRV_SD2', 'HRV_SD1SD2',
                'HRV_CSI', 'HRV_CVI', 'HRV_CSI_Modified', 'HRV_SampEn']
 
     # Test with signal dataframe

--- a/tests/tests_hrv.py
+++ b/tests/tests_hrv.py
@@ -57,6 +57,6 @@ def test_hrv():
                         'HRV_pNN50', 'HRV_pNN20', 'HRV_TINN', 'HRV_HTI', 'HRV_ULF',
                         'HRV_VLF', 'HRV_LF', 'HRV_HF', 'HRV_VHF', 'HRV_LFHF',
                         'HRV_LFn', 'HRV_HFn', 'HRV_LnHF',
-                        'HRV_SD1', 'HRV_SD2', 'HRV_SD2SD1', 'HRV_CSI', 'HRV_CVI',
+                        'HRV_SD1', 'HRV_SD2', 'HRV_SD1SD2', 'HRV_CSI', 'HRV_CVI',
                         'HRV_CSI_Modified', 'HRV_SampEn']
                for elem in np.array(ecg_hrv.columns.values, dtype=str))


### PR DESCRIPTION
# Description & Proposed Changes

I changed the SD2/SD1 ratio to SD1/SD2 since other implementations and references also compute this feature.


# Checklist

Here are some things to check before creating the PR.

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.