### PR TITLE
ecg_analyze should pass sampling_rate to ecg_intervalrelated call

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,6 +26,7 @@ Contributors
 * `Mitchell Bishop <https://github.com/Mitchellb16>`_ *(NINDS, USA)*
 * `Robert Richer <https://github.com/richrobe>`_ *(FAU Erlangen-Nürnberg, Germany)*
 * `Russell Anderson <https://github.com/rpanderson>`_ *(La Trobe Institute for Molecular Science, Australia)*
+* `Alexander Wong <https://github.com/awwong1>`_*(University of Alberta, Canada)*
 
 
 Thanks also to `Gansheng Tan <https://github.com/GanshengT>`_, `Chuan-Peng Hu <https://github.com/hcp4715>`_, `@ucohen <https://github.com/ucohen>`_, `Anthony Gatti <https://github.com/gattia>`_, `Julien Lamour <https://github.com/lamourj>`_, `@renatosc <https://github.com/renatosc>`_, `Nicolas Beaudoin-Gagnon <https://github.com/Fegalf>`_ and `@rubinovitz <https://github.com/rubinovitz>`_ for their contribution in `NeuroKit 1 <https://github.com/neuropsychology/NeuroKit.py>`_.

--- a/neurokit2/ecg/ecg_analyze.py
+++ b/neurokit2/ecg/ecg_analyze.py
@@ -94,7 +94,7 @@ def ecg_analyze(data, sampling_rate=1000, method="auto"):
 
     # Interval-related analysis
     elif method in ["interval-related", "interval", "resting-state"]:
-        features = ecg_intervalrelated(data)
+        features = ecg_intervalrelated(data, sampling_rate=sampling_rate)
 
     # Auto
     elif method in ["auto"]:
@@ -103,7 +103,7 @@ def ecg_analyze(data, sampling_rate=1000, method="auto"):
             for i in data:
                 duration = len(data[i]) / sampling_rate
             if duration >= 10:
-                features = ecg_intervalrelated(data)
+                features = ecg_intervalrelated(data, sampling_rate=sampling_rate)
             else:
                 features = ecg_eventrelated(data)
 
@@ -114,7 +114,7 @@ def ecg_analyze(data, sampling_rate=1000, method="auto"):
             else:
                 duration = len(data) / sampling_rate
             if duration >= 10:
-                features = ecg_intervalrelated(data)
+                features = ecg_intervalrelated(data, sampling_rate=sampling_rate)
             else:
                 features = ecg_eventrelated(data)
 


### PR DESCRIPTION
The behavior of `ecg_analyze(df, sampling_rate=500, method="interval-related")` should be identical to calling `ecg_intervalrelated(df, sampling_rate=500)`.

# Proposed Changes

I added the `sampling_rate` kwarg to all `ecg_intervalrelated` calls within `ecg_analyze`.

# Checklist

Here are some things to check before creating the PR.

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.