### PR TITLE
[Fix] ecg_delineate CWT mode crash when no consecutive tp peaks found

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,6 +27,7 @@ Contributors
 * `Robert Richer <https://github.com/richrobe>`_ *(FAU Erlangen-Nürnberg, Germany)*
 * `Russell Anderson <https://github.com/rpanderson>`_ *(La Trobe Institute for Molecular Science, Australia)*
 * `Alexander Wong <https://github.com/awwong1>`_ *(University of Alberta, Canada)*
+* `Raimon Padrós <https://github.com/raimonpv>`_ *(Universitat politècnica de Catalunya, Spain - Massachusetts General Hospital, USA)*
 
 
 Thanks also to `Gansheng Tan <https://github.com/GanshengT>`_, `Chuan-Peng Hu <https://github.com/hcp4715>`_, `@ucohen <https://github.com/ucohen>`_, `Anthony Gatti <https://github.com/gattia>`_, `Julien Lamour <https://github.com/lamourj>`_, `@renatosc <https://github.com/renatosc>`_, `Nicolas Beaudoin-Gagnon <https://github.com/Fegalf>`_ and `@rubinovitz <https://github.com/rubinovitz>`_ for their contribution in `NeuroKit 1 <https://github.com/neuropsychology/NeuroKit.py>`_.

--- a/tests/tests_ecg_delineate.py
+++ b/tests/tests_ecg_delineate.py
@@ -72,6 +72,7 @@ def test_find_ecg_characteristics(attribute, test_data):
     ecg_characteristics = run_test_func(test_data)
     diff = ecg_characteristics[attribute] - test_data[attribute]
     diff = diff[diff.abs() < 0.5 * test_data["sampling_rate"]]  # remove obvious failure
+    test_data[attribute] = test_data[attribute][~np.isnan(test_data[attribute])]
     diff = diff[~np.isnan(diff)]
     report = """
 Difference statistics

--- a/tests/tests_ecg_delineate.py
+++ b/tests/tests_ecg_delineate.py
@@ -72,6 +72,7 @@ def test_find_ecg_characteristics(attribute, test_data):
     ecg_characteristics = run_test_func(test_data)
     diff = ecg_characteristics[attribute] - test_data[attribute]
     diff = diff[diff.abs() < 0.5 * test_data["sampling_rate"]]  # remove obvious failure
+    diff = diff[~np.isnan(diff)]
     report = """
 Difference statistics
 {diff_describe}


### PR DESCRIPTION
# Description
Fix ecg_delineate bug described in neuropsychology/NeuroKit#309

# Proposed Changes

The bug reported is fixed in line 668-669 by returning a list with a np.nan instead of an empty list in `_find_tppeaks`. Additionally, I changed the type of array in `_peaks_delineator` and in `_onsets_offsets_delineator` to object as a an array with np nans cannot be converted to int. Finally, in `_onsets_offsets_delineator` if the peak is a np.nan now it appends a np.nan to the onsets and offsets list and don't do any calculation for this peak.

The problem is that by adding np.nans to the arrays, it forces the array to be a float array instead of int, which means that before using the indices for slicing you have to convert them to int. Another option is to convert the arrays into object arrays )which I did) but idk if it is computationally optimal.


Additional changes:
- Removed unnecessary for loop in `_peaks_delineator`
- Add a np.nan in the onsets and offsets list if len(wt_peaks) == 0 instead of using the continue statement in `_onset_offset_delineator`. In this way the length of the arrays will be of the same length as R peaks which in my opinion makes easier further analysis. Additionally, before you discard the option of looking for an offset if for the onset `len(wt_peaks) == 0` which doesn't necessarily mean that you won't find an offset. 
- Code in a similar way  `_dwt_delineate_tp_onsets_offsets` and `_dwt_delineate_qrs_bounds` to make the code clearer.

Feel free to discard/adapt any of the changes I've implemented.

# Checklist

Here are some things to check before creating the PR.

- [X] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [X] My PR is targetted at the **dev branch** (and not towards the master branch).
- [X] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.