### PR TITLE
[Fix] Review microstate implementations

### DIFF
--- a/neurokit2/microstates/microstates_segment.py
+++ b/neurokit2/microstates/microstates_segment.py
@@ -8,7 +8,7 @@ from ..stats.cluster_quality import _cluster_quality_gev
 
 
 def microstates_segment(eeg, n_microstates=4, train="gfp", method='kmod', gfp_method='l1', sampling_rate=None,
-                        standardize_eeg=False, n_runs=10, max_iterations=1000, criterion='gev', random_state=None, **kwargs):
+                        standardize_eeg=False, n_runs=10, max_iterations=1000, criterion='gev', random_state=None, optimize=False, **kwargs):
     """Segment a continuous M/EEG signal into microstates using different clustering algorithms.
 
     Several runs of the clustering algorithm are performed, using different random initializations.
@@ -62,6 +62,9 @@ def microstates_segment(eeg, n_microstates=4, train="gfp", method='kmod', gfp_me
         The seed or ``RandomState`` for the random number generator. Defaults
         to ``None``, in which case a different seed is chosen each time this
         function is called.
+     optimize : bool
+        To use a new optimized method in https://www.biorxiv.org/content/10.1101/289850v1.full.pdf.
+        For the k-means modified method. Default to False.
 
     Returns
     -------
@@ -155,7 +158,8 @@ def microstates_segment(eeg, n_microstates=4, train="gfp", method='kmod', gfp_me
                                          n_clusters=n_microstates,
                                          random_state=random_state[run],
                                          max_iterations=max_iterations,
-                                         threshold=1e-6)
+                                         threshold=1e-6,
+                                         optimize=optimize)
             current_microstates = current_info["clusters_normalized"]
             current_residual = current_info["residual"]
 

--- a/neurokit2/stats/cluster.py
+++ b/neurokit2/stats/cluster.py
@@ -244,11 +244,11 @@ def _cluster_kmod(data, n_clusters=4, max_iterations=1000, threshold=1e-6, rando
     clusters = data[init_times, :]
 
     # Normalize row-wise (across EEG channels)
-    clusters = clusters / np.sqrt(np.sum(clusters**2, axis=1, keepdims=True))
+    clusters /= np.linalg.norm(clusters, axis=1, keepdims=True)  # Normalize the maps
+
 
     # Initialize iteration
-    prev_residual = 1
-    residual = 0
+    prev_residual = 0
     for i in range(max_iterations):
 
         # Step 3: Assign each sample to the best matching microstate
@@ -290,11 +290,11 @@ def _cluster_kmod(data, n_clusters=4, max_iterations=1000, threshold=1e-6, rando
         residual = residual / np.float(n_samples * (n_channels - 1))
 
         # Have we converged? Convergence criterion: variance estimate (step 6)
-        if np.abs((prev_residual - residual) / prev_residual) < threshold:
+        if np.abs(prev_residual - residual) < (threshold * residual):
             break
 
         # Next iteration
-        prev_residual = residual
+        prev_residual = residual.copy()
 
     if i == max_iterations:
         warnings.warn("Modified K-means algorithm failed to converge after " + str(i) + "",

--- a/neurokit2/stats/cluster.py
+++ b/neurokit2/stats/cluster.py
@@ -322,7 +322,8 @@ def _cluster_kmod(data, n_clusters=4, max_iterations=1000, threshold=1e-6, rando
     info = {"n_clusters": n_clusters,
             "clustering_function": clustering_function,
             "random_state": random_state,
-            "clusters_normalized": clusters}
+            "clusters_normalized": clusters,
+            "residual": residual}
 
     return prediction, clusters_unnormalized, info
 

--- a/neurokit2/stats/cluster.py
+++ b/neurokit2/stats/cluster.py
@@ -276,13 +276,18 @@ def _cluster_kmod(data, n_clusters=4, max_iterations=1000, threshold=1e-6, rando
             # eigen_vals, eigen_vectors = scipy.linalg.eigh(cov, eigvals=(n_channels-1, n_channels-1))
             # # Get normalized map (method by Marijn)
             # state_vals = eigen_vectors.ravel()
-
             # Get map (method 2 - see https://github.com/wmvanvliet/mne_microstates/issues/5)
-            state_vals = data_state.T.dot(activation[state, idx])
-            state_vals /= np.linalg.norm(state_vals)  # Normalize Map
+            # state_vals = data_state.T.dot(activation[state, idx])
+            # state_vals /= np.linalg.norm(state_vals)
+            # clusters[state, :] = state_vals
 
-            # Store map
-            clusters[state, :] = state_vals
+            # step 4a
+            Sk = np.dot(data_state.T, data_state)
+            # step 4b
+            eigen_vals, eigen_vectors = scipy.linalg.eigh(Sk)
+            state_vals = eigen_vectors[:, np.argmax(np.abs(eigen_vals))]
+            state_vals /= np.linalg.norm(state_vals)  # Normalize Map
+            clusters[state, :] = state_vals  # Store map
 
         # Estimate residual noise (step 5)
         act_sum_sq = np.sum(np.sum(clusters[segmentation, :] * data, axis=1) ** 2)

--- a/neurokit2/stats/cluster_quality.py
+++ b/neurokit2/stats/cluster_quality.py
@@ -86,7 +86,7 @@ def cluster_quality(data, clustering, clusters=None, info=None, n_random=10, **k
 
     # Variance explained
     general["Score_VarianceExplained"] = _cluster_quality_variance(data, clusters)
-    general["Score_GEV"] = _cluster_quality_gev(data, clusters, clustering, **kwargs)
+    general["Score_GEV"], _ = _cluster_quality_gev(data, clusters, clustering, **kwargs)
     general["Score_CrossValidation"] = _cluster_quality_crossvalidation(data, clusters, clustering)
 
     # Gap statistic
@@ -213,9 +213,9 @@ def _cluster_quality_crossvalidation(data, clusters, clustering):
     var /= (n_rows * (n_cols - 1))
     try:
         cv = var * (n_cols - 1)**2 / (n_cols - len(clusters) - 1)**2
-    except ValueError:
+    except ZeroDivisionError:
         cv = var
-        warnings.warn("Number of columns in data (" + str(n_cols) + ") is smaller",
+        warnings.warn("Number of columns in data (" + str(n_cols) + ") is smaller "
                       "than the number of cluster (" + str(len(clusters)) + ") plus 1."
                       "Returnin the residual noise instead.")
 #    cv = var * (n_cols - 1)**2 / len(clusters)


### PR DESCRIPTION
Microstates list:

- [x] Check current mod k-means against https://github.com/Frederic-vW/eeg_microstates/blob/master/eeg_microstates.py#L518
- [x] Check other methods (ICA, PCA, AAHC etc.)

- [ ] Check peak detection, 'cause most of the publications find the GFP peaks, BUT for instance [here](https://www.researchgate.net/publication/7432398_Response_inhibition_deficits_in_externalizing_child_psychiatric_disorders_An_ERP-study_with_the_Stop-task) it says *"Microstate boarders were determined by relative **minima of GFP** together with relative **maxima in Diss**."*
- [x] cross validation index: https://github.com/Frederic-vW/eeg_microstates/blob/master/eeg_microstates.py#L594

Tried to implement it in clusters_quality but gives funny results. (especially the normalization part doesn't work).

- [x] GEV

Implementations from https://github.com/Frederic-vW/eeg_microstates/blob/master/eeg_microstates.py#L602 and https://github.com/wmvanvliet/mne_microstates/blob/master/microstates.py#L126 (added my version of both in clusters_quality) give very different results. Also, it would be good to get the GEV per microstate, which currently isn't computed it seems.

 