### PR TITLE
input check for series when non-default index is set.

### DIFF
--- a/neurokit2/eda/eda_process.py
+++ b/neurokit2/eda/eda_process.py
@@ -66,7 +66,7 @@ def eda_process(eda_signal, sampling_rate=1000, method="neurokit"):
     """
     # Series check for non-default index
     if type(eda_signal) is pd.Series and type(eda_signal.index) != pd.RangeIndex:
-        eda_signal.reset_index(inplace=True, drop=True)
+        eda_signal = eda_signal.reset_index(drop=True)
 
     # Preprocess
     eda_cleaned = eda_clean(eda_signal, sampling_rate=sampling_rate, method=method)

--- a/neurokit2/eda/eda_process.py
+++ b/neurokit2/eda/eda_process.py
@@ -64,6 +64,10 @@ def eda_process(eda_signal, sampling_rate=1000, method="neurokit"):
     >>> fig #doctest: +SKIP
 
     """
+    # Series check for non-default index
+    if type(eda_signal) is pd.Series and type(eda_signal.index) != pd.RangeIndex:
+        eda_signal.reset_index(inplace=True, drop=True)
+
     # Preprocess
     eda_cleaned = eda_clean(eda_signal, sampling_rate=sampling_rate, method=method)
     eda_decomposed = eda_phasic(eda_cleaned, sampling_rate=sampling_rate)


### PR DESCRIPTION
# Description

When the given signal has Index set then Pandas's concat is not working correctly
    [Problem] (https://stackoverflow.com/questions/32801806/pandas-concat-ignore-index-doesnt-work)

I made changes on the only eda_process.py however, there are other files that need to be fixed. 
If you agree with this change, then we can fix others as well. 

However, since the type check can be the same for all the files, we can write a function that we can call for all the files.

Please let me know what do you think?

Best regards,
Celal

    
# Proposed Changes
Reset_index only when the input is series and has an index other than the default
As an example, I have made changes in eda_process.py

` 
# Series check for non-default index
    if type(eda_signal) is pd.Series and type(eda_signal.index) != pd.RangeIndex:
        eda_signal.reset_index(inplace=True, drop=True)
`

# Checklist

- [ X] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [ X] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ X] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.