### PR TITLE
signal_sanitize() added, when non-default index for pandas series cau…

### DIFF
--- a/neurokit2/ecg/ecg_process.py
+++ b/neurokit2/ecg/ecg_process.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pandas as pd
 
-from ..signal import signal_rate
+from ..signal import signal_rate, signal_sanitize
 from .ecg_clean import ecg_clean
 from .ecg_delineate import ecg_delineate
 from .ecg_peaks import ecg_peaks
@@ -89,6 +89,9 @@ def ecg_process(ecg_signal, sampling_rate=1000, method="neurokit"):
     <Figure ...>
 
     """
+    # Sanitize input
+    ecg_signal = signal_sanitize(ecg_signal)
+
     ecg_cleaned = ecg_clean(ecg_signal, sampling_rate=sampling_rate, method=method)
     # R-peaks
     instant_peaks, rpeaks, = ecg_peaks(

--- a/neurokit2/eda/eda_process.py
+++ b/neurokit2/eda/eda_process.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pandas as pd
 
+from ..signal import signal_sanitize
 from .eda_clean import eda_clean
 from .eda_peaks import eda_peaks
 from .eda_phasic import eda_phasic
@@ -64,6 +65,9 @@ def eda_process(eda_signal, sampling_rate=1000, method="neurokit"):
     >>> fig #doctest: +SKIP
 
     """
+    # Sanitize input
+    eda_signal = signal_sanitize(eda_signal)
+    
     # Series check for non-default index
     if type(eda_signal) is pd.Series and type(eda_signal.index) != pd.RangeIndex:
         eda_signal = eda_signal.reset_index(drop=True)

--- a/neurokit2/emg/emg_process.py
+++ b/neurokit2/emg/emg_process.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pandas as pd
 
+from ..signal import signal_sanitize
 from .emg_activation import emg_activation
 from .emg_amplitude import emg_amplitude
 from .emg_clean import emg_clean
@@ -47,6 +48,9 @@ def emg_process(emg_signal, sampling_rate=1000):
     >>> fig #doctest: +SKIP
 
     """
+    # Sanitize input
+    emg_signal = signal_sanitize(emg_signal)
+
     # Clean signal
     emg_cleaned = emg_clean(emg_signal, sampling_rate=sampling_rate)
 

--- a/neurokit2/rsp/rsp_process.py
+++ b/neurokit2/rsp/rsp_process.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pandas as pd
 
-from ..signal import signal_rate
+from ..signal import signal_rate, signal_sanitize
 from .rsp_amplitude import rsp_amplitude
 from .rsp_clean import rsp_clean
 from .rsp_peaks import rsp_peaks
@@ -60,6 +60,9 @@ def rsp_process(rsp_signal, sampling_rate=1000, method="khodadad2018"):
     >>> fig #doctest: +SKIP
 
     """
+    # Sanitize input
+    rsp_signal = signal_sanitize(rsp_signal)
+
     # Clean signal
     rsp_cleaned = rsp_clean(rsp_signal, sampling_rate=sampling_rate, method=method)
 

--- a/neurokit2/signal/__init__.py
+++ b/neurokit2/signal/__init__.py
@@ -25,6 +25,7 @@ from .signal_smooth import signal_smooth
 from .signal_synchrony import signal_synchrony
 from .signal_zerocrossings import signal_zerocrossings
 from .signal_timefrequency import signal_timefrequency
+from .signal_sanitize import signal_sanitize
 
 
 __all__ = [
@@ -52,5 +53,6 @@ __all__ = [
     "signal_changepoints",
     "signal_decompose",
     "signal_recompose",
-    "signal_timefrequency"
+    "signal_timefrequency",
+    "signal_sanitize"
 ]

--- a/neurokit2/signal/signal_sanitize.py
+++ b/neurokit2/signal/signal_sanitize.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import pandas as pd
+
+
+def signal_sanitize(signal):
+    """Reset indexing for Pandas Series
+
+    Parameters
+    ----------
+    signal : Series
+        The indexed input signal (pandas set_index())
+
+    Returns
+    -------
+    Series
+        The default indexed signal
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import neurokit2 as nk
+    >>>
+    >>> signal = nk.signal_simulate(duration=10, sampling_rate=1000, frequency=1)
+    >>> df = pd.DataFrame({'signal': signal, 'id': [x*2 for x in range(len(signal))]})
+    >>>
+    >>> df = df.set_index('id')
+    >>> default_index_signal = nk.signal_sanitize(df.signal)
+    >>>
+
+    """
+
+    # Series check for non-default index
+    if type(signal) is pd.Series and type(signal.index) != pd.RangeIndex:
+        return signal.reset_index(drop=True)
+
+    return signal


### PR DESCRIPTION
# Description
signal_sanitize() added, when non-default index for pandas series causing pd.concat to fail. For more backgound and context see #371.

# Proposed Changes
a function added under signal/ folder. 
signal_sanitize().py -> signal_sanitize()

# Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.