### PR TITLE
Fix casting to np.int64

### DIFF
--- a/neurokit2/ecg/ecg_delineate.py
+++ b/neurokit2/ecg/ecg_delineate.py
@@ -150,8 +150,8 @@ def ecg_delineate(
 def _dwt_resample_points(peaks, sampling_rate, desired_sampling_rate):
     """Resample given points to a different sampling rate."""
     if isinstance(peaks, np.ndarray):    # peaks are passed in from previous processing steps
-        # Prevent overflow by casting to np.int64 (peaks might be passed in containing np.int32).
-        peaks.astype(dtype=np.int64, copy=False)
+        # Prevent overflow by converting to np.int64 (peaks might be passed in containing np.int32).
+        peaks = peaks.astype(dtype=np.int64)
     elif isinstance(peaks, list):    # peaks returned from internal functions
         # Cannot be converted to int since list might contain np.nan. Automatically cast to np.float64 if list contains np.nan.
         peaks = np.array(peaks)


### PR DESCRIPTION
# Description

This PR fixes the changes made in 2fb051df12a29dd3e74c0a67a9d61c414254d007 which aimed to prevent an integer overflow in `_dwt_resample_points`. See #387.

# Proposed Changes

`numpy.ndarray.astype` will still copy with `copy=False` if the `dtype` argument [requirement is not satisfied](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.astype.html). (Converting an int32 array to a int64 array always needs to copy.)
