### PR TITLE
fix error when len(candidate_offsets)==0

### DIFF
--- a/neurokit2/ecg/ecg_delineate.py
+++ b/neurokit2/ecg/ecg_delineate.py
@@ -369,7 +369,7 @@ def _dwt_delineate_tp_onsets_offsets(
             offsets.append(np.nan)
             continue
         candidate_offsets = np.where(-dwt_local[offset_slope_peaks[0] :] < epsilon_offset)[0] + offset_slope_peaks[0]
-        if(len(candidate_offsets)>0):
+        if(len(candidate_offsets) > 0):
             offsets.append(candidate_offsets[0] + srch_idx_start)
         else:
             offsets.append(np.nan)

--- a/neurokit2/ecg/ecg_delineate.py
+++ b/neurokit2/ecg/ecg_delineate.py
@@ -369,7 +369,10 @@ def _dwt_delineate_tp_onsets_offsets(
             offsets.append(np.nan)
             continue
         candidate_offsets = np.where(-dwt_local[offset_slope_peaks[0] :] < epsilon_offset)[0] + offset_slope_peaks[0]
-        offsets.append(candidate_offsets[0] + srch_idx_start)
+        if(len(candidate_offsets)>0):
+            offsets.append(candidate_offsets[0] + srch_idx_start)
+        else:
+            offsets.append(np.nan)
 
         # # only for debugging
         # events_plot([candidate_offsets, offset_slope_peaks], dwt_local)


### PR DESCRIPTION
# Description

This PR aims at fix _dwt_delineate_tp_onsets_offsets fucntion when the there is no candidate_offsets.

# Proposed Changes

I changed the `_dwt_delineate_tp_onsets_offsets ()` function so that won't show error when len(candidate_offsets)==0

