### PR TITLE
[Fix] Fix signal_zerocrossings indexing issues

### DIFF
--- a/neurokit2/ecg/ecg_delineate.py
+++ b/neurokit2/ecg/ecg_delineate.py
@@ -261,7 +261,7 @@ def _dwt_delineate_tp_peaks(
         for idx_peak, idx_peak_nxt in zip(peaks[:-1], peaks[1:]):
             correct_sign = dwt_local[idx_peak] > 0 and dwt_local[idx_peak_nxt] < 0  # pylint: disable=R1716
             if correct_sign:
-                idx_zero = signal_zerocrossings(dwt_local[idx_peak:idx_peak_nxt])[0] + idx_peak
+                idx_zero = signal_zerocrossings(dwt_local[idx_peak:idx_peak_nxt+1])[0] + idx_peak
                 # This is the score assigned to each peak. The peak with the highest score will be
                 # selected.
                 score = ecg_local[idx_zero] - (float(idx_zero) / sampling_rate - (rt_duration - 0.5 * qrs_width))
@@ -302,7 +302,7 @@ def _dwt_delineate_tp_peaks(
         for idx_peak, idx_peak_nxt in zip(peaks[:-1], peaks[1:]):
             correct_sign = dwt_local[idx_peak] > 0 and dwt_local[idx_peak_nxt] < 0  # pylint: disable=R1716
             if correct_sign:
-                idx_zero = signal_zerocrossings(dwt_local[idx_peak:idx_peak_nxt])[0] + idx_peak
+                idx_zero = signal_zerocrossings(dwt_local[idx_peak:idx_peak_nxt+1])[0] + idx_peak
                 # This is the score assigned to each peak. The peak with the highest score will be
                 # selected.
                 score = ecg_local[idx_zero] - abs(
@@ -667,7 +667,7 @@ def _find_tppeaks(ecg, keep_tp, sampling_rate=1000):
         #    near = (index_next - index_cur) < max_wv_peak_dist #limit 2
         #    if near and correct_sign:
         if correct_sign:
-            index_zero_cr = signal_zerocrossings(cwtmatr[4, :][index_cur:index_next])[0] + index_cur
+            index_zero_cr = signal_zerocrossings(cwtmatr[4, :][index_cur:index_next+1])[0] + index_cur
             nb_idx = int(max_search_duration * sampling_rate)
             index_max = np.argmax(ecg[index_zero_cr - nb_idx : index_zero_cr + nb_idx]) + (index_zero_cr - nb_idx)
             tppeaks.append(index_max)

--- a/neurokit2/ecg/ecg_findpeaks.py
+++ b/neurokit2/ecg/ecg_findpeaks.py
@@ -919,7 +919,7 @@ def _ecg_findpeaks_WT(signal, sampling_rate=1000):
         correct_sign = signal_1[index_cur] < 0 and signal_1[index_next] > 0  # pylint: disable=R1716
         near = (index_next - index_cur) < max_R_peak_dist  # limit 2
         if near and correct_sign:
-            rpeaks.append(signal_zerocrossings(signal_1[index_cur:index_next])[0] + index_cur)
+            rpeaks.append(signal_zerocrossings(signal_1[index_cur:index_next+1])[0] + index_cur)
 
     rpeaks = np.array(rpeaks, dtype="int")
     return rpeaks


### PR DESCRIPTION
# Description

Throughout the package, signal_zerocrossings is used to find indices where signal crosses 0. Before calling signal_zerocrossings, signals are, correctly, checked to ensure that peaks[current_idx] is positive and peaks[next_idx] is negative. However, peaks[current_idx:next_idx] is used in the signal_zerocrossings call, excluding peaks[next_idx] value. When signal is positive until x[next_idx], the function currently throws error.

# Proposed Changes

All signal_zerocrossings calls are changed so that the second peak is included in signal_zerocrossings calls. That is, peaks[current_idx:next_idx] becomes peaks[current_idx:next_idx+1] in all cases. 
