### PR TITLE
Stop signal_fixpeaks iteration when number of artifacts stops decreasing

### DIFF
--- a/neurokit2/signal/signal_fixpeaks.py
+++ b/neurokit2/signal/signal_fixpeaks.py
@@ -156,23 +156,22 @@ def _signal_fixpeaks_kubios(peaks, sampling_rate=1000, iterative=True, show=Fals
 
     if iterative:
 
-        # Iteratively apply the artifact correction until the number of artifact
-        # reaches an equilibrium (i.e., the number of artifacts does not change
-        # anymore from one iteration to the next).
-        n_artifacts_previous = np.inf
+        # Iteratively apply the artifact correction until the number
+        # of artifacts stops decreasing.
         n_artifacts_current = sum([len(i) for i in artifacts.values()])
 
-        previous_diff = 0
+        while True:
 
-        while n_artifacts_current - n_artifacts_previous != previous_diff:
-
-            previous_diff = n_artifacts_previous - n_artifacts_current
-
-            artifacts, subspaces = _find_artifacts(peaks_clean, sampling_rate=sampling_rate)
-            peaks_clean = _correct_artifacts(artifacts, peaks_clean)
+            new_artifacts, new_subspaces = _find_artifacts(peaks_clean, sampling_rate=sampling_rate)
 
             n_artifacts_previous = n_artifacts_current
-            n_artifacts_current = sum([len(i) for i in artifacts.values()])
+            n_artifacts_current = sum([len(i) for i in new_artifacts.values()])
+            if n_artifacts_current >= n_artifacts_previous:
+                break
+
+            artifacts = new_artifacts
+            subspaces = new_subspaces
+            peaks_clean = _correct_artifacts(artifacts, peaks_clean)
 
     if show:
         _plot_artifacts_lipponen2019(artifacts, subspaces)

--- a/tests/tests_signal_fixpeaks.py
+++ b/tests/tests_signal_fixpeaks.py
@@ -154,7 +154,7 @@ def idfn(val):
 
 @pytest.mark.parametrize(
     "peaks_misaligned, iterative, rmssd_diff",
-    [(2, True, 34), (2, False, 27), (4, True, 133), (4, False, 113), (8, True, 466), (8, False, 444)],
+    [(2, True, 27), (2, False, 27), (4, True, 113), (4, False, 113), (8, True, 444), (8, False, 444)],
     indirect=["peaks_misaligned"],
     ids=idfn,
 )


### PR DESCRIPTION
# Description

Fixes neuropsychology/NeuroKit#378

# Proposed Changes

This change stops the iteration in `_signal_fixpeaks_kubios` when the number of detected artifacts stops decreasing. This logic is guaranteed to stop as the number of artifacts can't drop below zero.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.