### PR TITLE
Added mne as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def find_version():
 
 
 # Dependencies
-requirements = ["numpy", "pandas", "scipy", "scikit-learn", "matplotlib"]
+requirements = ["numpy", "pandas", "scipy", "scikit-learn", "matplotlib", "mne"]
 
 # Optional Dependencies (only needed / downloaded for testing purposes, for instance to test against some other packages)
 setup_requirements = ["pytest-runner", "numpy"]


### PR DESCRIPTION
# Description

Adds `mne` as a package dependency, since it's required for some functions to work (e.g. `eeg.eeg_diss`). See Issue #403.

# Proposed Changes

I've added it to `setup.py` so it's installed when importing the package with `pip`.


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.