### PR TITLE
Optimize _ecg_findpeaks_MWA

### DIFF
--- a/neurokit2/ecg/ecg_findpeaks.py
+++ b/neurokit2/ecg/ecg_findpeaks.py
@@ -1021,14 +1021,7 @@ def _ecg_findpeaks_MWA(signal, window_size):
     # difference of the cumulative sum across `window_size` elements.
     mwa_tail = (sums[window_size:] - sums[:-window_size]) / window_size
 
-    # TODO: Is the following construct intentional? This produces exactly
-    # equal output as the code before the above optimization, but the shift
-    # by one seems like a potential bug in the earlier code. See the test
-    # case in tests/tests_ecg_findpeaks_MWA.py for example output.
-    mwa = np.concatenate([signal[0:1], mwa_head, mwa_tail[:-1]])
-    # Here's a possibly more correct version:
-    # mwas = np.concatenate([mwa_head, mwa_tail])
-    return mwa
+    return np.concatenate([mwa_head, mwa_tail])
 
 
 def _ecg_findpeaks_peakdetect(detection, sampling_rate=1000):

--- a/tests/tests_ecg_findpeaks_MWA.py
+++ b/tests/tests_ecg_findpeaks_MWA.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+import pytest
+
+# Trick to directly access the internal function.
+# Using neurokit2.ecg.ecg_findpeaks._ecg_findpeaks_MWA doesn't
+# work because of the "from .ecg_findpeaks import ecg_findpeaks"
+# statement in neurokit2/ecg/__init.__.py.
+from neurokit2.ecg.ecg_findpeaks import _ecg_findpeaks_MWA
+
+
+# TODO: Is the expected output asserted by this test correct?
+# See the comment in _ecg_findpeaks_MWA for more details.
+def test_ecg_findpeaks_MWA():
+    np.testing.assert_array_equal(
+        _ecg_findpeaks_MWA(
+            np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.float),
+            3),
+        [0, 0, 0.5, 1, 2, 3, 4, 5, 6, 7])

--- a/tests/tests_ecg_findpeaks_MWA.py
+++ b/tests/tests_ecg_findpeaks_MWA.py
@@ -9,11 +9,9 @@ import pytest
 from neurokit2.ecg.ecg_findpeaks import _ecg_findpeaks_MWA
 
 
-# TODO: Is the expected output asserted by this test correct?
-# See the comment in _ecg_findpeaks_MWA for more details.
 def test_ecg_findpeaks_MWA():
     np.testing.assert_array_equal(
         _ecg_findpeaks_MWA(
             np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.float),
             3),
-        [0, 0, 0.5, 1, 2, 3, 4, 5, 6, 7])
+        [0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8])


### PR DESCRIPTION
This optimization speeds up the moving average computation by an order of
magnitude. This is the most time-consuming part of pantompkins peak
detection, which after this optimization is about 5x faster on my computer.

Note the TODO about the _ecg_findpeaks_MWA output. I intentionally kept
this as a pure optimization with no impact on the output of the function,
but I do wonder whether the earlier implementation was actually incorrect,
or if the output is intentionally shifted by one.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.