### PR TITLE
Fixed issue #421:  ragged nested sequences

### DIFF
--- a/neurokit2/eda/eda_findpeaks.py
+++ b/neurokit2/eda/eda_findpeaks.py
@@ -286,7 +286,6 @@ def _eda_findpeaks_kim2004(eda_phasic, sampling_rate=1000, amplitude_min=0.1):
             ZC += [zeros[i + 1]]
             pks += [zeros[i] + np.argmax(df[zeros[i] : zeros[i + 1]])]
 
-    scrs = np.array(scrs, dtype=object)
     amps = np.array(amps)
     ZC = np.array(ZC)
     pks = np.array(pks)

--- a/neurokit2/eda/eda_findpeaks.py
+++ b/neurokit2/eda/eda_findpeaks.py
@@ -286,7 +286,7 @@ def _eda_findpeaks_kim2004(eda_phasic, sampling_rate=1000, amplitude_min=0.1):
             ZC += [zeros[i + 1]]
             pks += [zeros[i] + np.argmax(df[zeros[i] : zeros[i + 1]])]
 
-    scrs = np.array(scrs)
+    scrs = np.array(scrs, dtype=object)
     amps = np.array(amps)
     ZC = np.array(ZC)
     pks = np.array(pks)


### PR DESCRIPTION

# Description

This is to fixed the issue number [#421](https://github.com/neuropsychology/NeuroKit/issues/421)

# Proposed Changes

In eda_findpeaks.py, I replaced 

```python
scrs = np.array(scrs)
```
with
```python
scrs = np.array(scrs, dtype=object)
```


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.