### PR TITLE
Boxcar

### DIFF
--- a/neurokit2/ecg/ecg_findpeaks.py
+++ b/neurokit2/ecg/ecg_findpeaks.py
@@ -5,8 +5,7 @@ import pandas as pd
 import scipy.signal
 import scipy.stats
 
-from ..signal import (signal_findpeaks, signal_plot, signal_sanitize,
-                      signal_smooth, signal_zerocrossings)
+from ..signal import signal_findpeaks, signal_plot, signal_sanitize, signal_smooth, signal_zerocrossings
 
 
 def ecg_findpeaks(ecg_cleaned, sampling_rate=1000, method="neurokit", show=False):
@@ -325,8 +324,7 @@ def _ecg_findpeaks_pantompkins(signal, sampling_rate=1000):
 # Nabian et al. (2018)
 # ===========================================================================
 def _ecg_findpeaks_nabian2018(signal, sampling_rate=1000):
-    """R peak detection method by Nabian et al. (2018) inspired by the Pan-Tompkins
-    algorithm.
+    """R peak detection method by Nabian et al. (2018) inspired by the Pan-Tompkins algorithm.
 
     - Nabian, M., Yin, Y., Wormwood, J., Quigley, K. S., Barrett, L. F., &amp; Ostadabbas, S. (2018).
     An Open-Source Feature Extraction Tool for the Analysis of Peripheral Physiological Data.
@@ -338,11 +336,11 @@ def _ecg_findpeaks_nabian2018(signal, sampling_rate=1000):
 
     peaks = np.zeros(len(signal))
 
-    for i in range(1+window_size, len(signal)-window_size):
-        ecg_window = signal[i-window_size:i+window_size]
+    for i in range(1 + window_size, len(signal) - window_size):
+        ecg_window = signal[i - window_size : i + window_size]
         rpeak = np.argmax(ecg_window)
 
-        if i == (i-window_size-1+rpeak):
+        if i == (i - window_size - 1 + rpeak):
             peaks[i] = 1
 
     rpeaks = np.where(peaks == 1)[0]
@@ -350,6 +348,7 @@ def _ecg_findpeaks_nabian2018(signal, sampling_rate=1000):
     # min_distance = 200
 
     return rpeaks
+
 
 # =============================================================================
 # Hamilton (2002)
@@ -784,11 +783,11 @@ def _ecg_findpeaks_kalidas(signal, sampling_rate=1000):
     # Try loading pywt
     try:
         import pywt
-    except ImportError:
+    except ImportError as import_error:
         raise ImportError(
             "NeuroKit error: ecg_findpeaks(): the 'PyWavelets' module is required for"
             " this method to run. Please install it first (`pip install PyWavelets`)."
-        )
+        ) from import_error
 
     swt_level = 3
     padding = -1
@@ -872,11 +871,11 @@ def _ecg_findpeaks_WT(signal, sampling_rate=1000):
     # Try loading pywt
     try:
         import pywt
-    except ImportError:
+    except ImportError as import_error:
         raise ImportError(
             "NeuroKit error: ecg_delineator(): the 'PyWavelets' module is required for"
             " this method to run. Please install it first (`pip install PyWavelets`)."
-        )
+        ) from import_error
     # first derivative of the Gaissian signal
     scales = np.array([1, 2, 4, 8, 16])
     cwtmatr, __ = pywt.cwt(signal, scales, "gaus1", sampling_period=1.0 / sampling_rate)
@@ -923,7 +922,7 @@ def _ecg_findpeaks_WT(signal, sampling_rate=1000):
         correct_sign = signal_1[index_cur] < 0 and signal_1[index_next] > 0  # pylint: disable=R1716
         near = (index_next - index_cur) < max_R_peak_dist  # limit 2
         if near and correct_sign:
-            rpeaks.append(signal_zerocrossings(signal_1[index_cur:index_next+1])[0] + index_cur)
+            rpeaks.append(signal_zerocrossings(signal_1[index_cur : index_next + 1])[0] + index_cur)
 
     rpeaks = np.array(rpeaks, dtype="int")
     return rpeaks
@@ -1009,6 +1008,7 @@ def _ecg_findpeaks_MWA(signal, window_size):
     """Based on https://github.com/berndporr/py-ecg-detectors/
 
     Optimized for vectorized computation.
+
     """
 
     window_size = int(window_size)
@@ -1021,8 +1021,7 @@ def _ecg_findpeaks_MWA(signal, window_size):
     # return causal moving averages, i.e. each output element is the average
     # of window_size input elements ending at that position, we use the
     # `origin` argument to shift the filter computation accordingly.
-    mwa = scipy.ndimage.uniform_filter1d(
-        signal, window_size, origin=(window_size - 1) // 2)
+    mwa = scipy.ndimage.uniform_filter1d(signal, window_size, origin=(window_size - 1) // 2)
 
     # Compute actual moving averages for the first `window_size - 1` elements,
     # which the uniform_filter1d function computes using padding. We want

--- a/neurokit2/signal/signal_smooth.py
+++ b/neurokit2/signal/signal_smooth.py
@@ -91,12 +91,12 @@ def signal_smooth(signal, method="convolution", kernel="boxzen", size=10, alpha=
         if kernel == "boxcar":
             # This is faster than using np.convolve (like is done in _signal_smoothing)
             # because of optimizations made possible by the uniform boxcar kernel shape.
-            smoothed = scipy.ndimage.uniform_filter1d(signal, size, mode='nearest')
+            smoothed = scipy.ndimage.uniform_filter1d(signal, size, mode="nearest")
 
         elif kernel == "boxzen":
             # hybrid method
             # 1st pass - boxcar kernel
-            x = scipy.ndimage.uniform_filter1d(signal, size, mode='nearest')
+            x = scipy.ndimage.uniform_filter1d(signal, size, mode="nearest")
 
             # 2nd pass - parzen kernel
             smoothed = _signal_smoothing(x, kernel="parzen", size=size)

--- a/neurokit2/signal/signal_timefrequency.py
+++ b/neurokit2/signal/signal_timefrequency.py
@@ -1,15 +1,27 @@
 # -*- coding: utf-8 -*-
+import matplotlib.pyplot as plt
 import numpy as np
 import scipy.signal
-import matplotlib.pyplot as plt
 
 from ..signal.signal_detrend import signal_detrend
 
 
-def signal_timefrequency(signal, sampling_rate=1000, min_frequency=0.04, max_frequency=None, method="stft", window=None, window_type='hann', mode='psd', nfreqbin=None, overlap=None, analytical_signal=True, show=True):
-    """Quantify changes of a nonstationary signal’s frequency over time.
-    The objective of time-frequency analysis is to offer a more informative description of the signal
-    which reveals the temporal variation of its frequency contents.
+def signal_timefrequency(
+    signal,
+    sampling_rate=1000,
+    min_frequency=0.04,
+    max_frequency=None,
+    method="stft",
+    window=None,
+    window_type="hann",
+    mode="psd",
+    nfreqbin=None,
+    overlap=None,
+    analytical_signal=True,
+    show=True,
+):
+    """Quantify changes of a nonstationary signal’s frequency over time. The objective of time-frequency analysis is to
+    offer a more informative description of the signal which reveals the temporal variation of its frequency contents.
 
     There are many different Time-Frequency Representations (TFRs) available:
 
@@ -86,6 +98,7 @@ def signal_timefrequency(signal, sampling_rate=1000, min_frequency=0.04, max_fre
     >>> f, t, cwtm = nk.signal_timefrequency(signal, sampling_rate, max_frequency=20, method="cwt", show=True)
     >>> f, t, wvd = nk.signal_timefrequency(signal, sampling_rate, max_frequency=20, method="wvd", show=True)
     >>> f, t, pwvd = nk.signal_timefrequency(signal, sampling_rate, max_frequency=20, method="pwvd", show=True)
+
     """
     # Initialize empty container for results
     # Define window length
@@ -98,68 +111,64 @@ def signal_timefrequency(signal, sampling_rate=1000, min_frequency=0.04, max_fre
     if method.lower() in ["stft"]:
 
         frequency, time, tfr = short_term_ft(
-                signal,
-                sampling_rate=sampling_rate,
-                overlap=overlap,
-                window=window,
-                mode=mode,
-                min_frequency=min_frequency,
-                window_type=window_type
-                )
+            signal,
+            sampling_rate=sampling_rate,
+            overlap=overlap,
+            window=window,
+            mode=mode,
+            min_frequency=min_frequency,
+            window_type=window_type,
+        )
     # CWT
     elif method.lower() in ["cwt", "wavelet"]:
         frequency, time, tfr = continuous_wt(
-                signal,
-                sampling_rate=sampling_rate,
-                min_frequency=min_frequency,
-                max_frequency=max_frequency
-                )
+            signal, sampling_rate=sampling_rate, min_frequency=min_frequency, max_frequency=max_frequency
+        )
     # WVD
     elif method in ["WignerVille", "wvd"]:
         frequency, time, tfr = wvd(
-                signal,
-                sampling_rate=sampling_rate,
-                n_freqbins=nfreqbin,
-                analytical_signal=analytical_signal,
-                method="WignerVille"
-                )
+            signal,
+            sampling_rate=sampling_rate,
+            n_freqbins=nfreqbin,
+            analytical_signal=analytical_signal,
+            method="WignerVille",
+        )
     # pseudoWVD
     elif method in ["pseudoWignerVille", "pwvd"]:
         frequency, time, tfr = wvd(
-                signal,
-                sampling_rate=sampling_rate,
-                n_freqbins=nfreqbin,
-                analytical_signal=analytical_signal,
-                method="pseudoWignerVille"
-                )
+            signal,
+            sampling_rate=sampling_rate,
+            n_freqbins=nfreqbin,
+            analytical_signal=analytical_signal,
+            method="pseudoWignerVille",
+        )
 
     # Sanitize output
     lower_bound = len(frequency) - len(frequency[frequency >= min_frequency])
     f = frequency[(frequency >= min_frequency) & (frequency <= max_frequency)]
-    z = tfr[lower_bound:lower_bound + len(f)]
-
+    z = tfr[lower_bound : lower_bound + len(f)]
 
     if show is True:
         plot_timefrequency(
-                z,
-                time,
-                f,
-                signal=signal,
-                method=method,
-                )
-
+            z,
+            time,
+            f,
+            signal=signal,
+            method=method,
+        )
 
     return f, time, z
+
 
 # =============================================================================
 # Short-Time Fourier Transform (STFT)
 # =============================================================================
 
 
-def short_term_ft(signal, sampling_rate=1000, min_frequency=0.04, overlap=None,
-                  window=None, window_type='hann', mode='psd'):
-    """Short-term Fourier Transform.
-    """
+def short_term_ft(
+    signal, sampling_rate=1000, min_frequency=0.04, overlap=None, window=None, window_type="hann", mode="psd"
+):
+    """Short-term Fourier Transform."""
 
     if window is not None:
         nperseg = int(window * sampling_rate)
@@ -171,12 +180,12 @@ def short_term_ft(signal, sampling_rate=1000, min_frequency=0.04, overlap=None,
         signal,
         fs=sampling_rate,
         window=window_type,
-        scaling='density',
+        scaling="density",
         nperseg=nperseg,
         nfft=None,
         detrend=False,
         noverlap=overlap,
-        mode=mode
+        mode=mode,
     )
 
     return frequency, time, np.abs(tfr)
@@ -190,20 +199,21 @@ def short_term_ft(signal, sampling_rate=1000, min_frequency=0.04, overlap=None,
 def continuous_wt(signal, sampling_rate=1000, min_frequency=0.04, max_frequency=None, nfreqbin=None):
     """Continuous Wavelet Transform.
 
-    References
-    ----------
-    - Neto, O. P., Pinheiro, A. O., Pereira Jr, V. L., Pereira, R., Baltatu, O. C., & Campos, L. A. (2016).
-    Morlet wavelet transforms of heart rate variability for autonomic nervous system activity.
-    Applied and Computational Harmonic Analysis, 40(1), 200-206.
+     References
+     ----------
+     - Neto, O. P., Pinheiro, A. O., Pereira Jr, V. L., Pereira, R., Baltatu, O. C., & Campos, L. A. (2016).
+     Morlet wavelet transforms of heart rate variability for autonomic nervous system activity.
+     Applied and Computational Harmonic Analysis, 40(1), 200-206.
 
-   - Wachowiak, M. P., Wachowiak-Smolíková, R., Johnson, M. J., Hay, D. C., Power, K. E.,
-   & Williams-Bell, F. M. (2018). Quantitative feature analysis of continuous analytic wavelet transforms
-   of electrocardiography and electromyography. Philosophical Transactions of the Royal Society A:
-   Mathematical, Physical and Engineering Sciences, 376(2126), 20170250.
+    - Wachowiak, M. P., Wachowiak-Smolíková, R., Johnson, M. J., Hay, D. C., Power, K. E.,
+    & Williams-Bell, F. M. (2018). Quantitative feature analysis of continuous analytic wavelet transforms
+    of electrocardiography and electromyography. Philosophical Transactions of the Royal Society A:
+    Mathematical, Physical and Engineering Sciences, 376(2126), 20170250.
+
     """
 
     # central frequency
-    w = 6.  # recommended
+    w = 6.0  # recommended
 
     if nfreqbin is None:
         nfreqbin = sampling_rate // 2
@@ -225,8 +235,7 @@ def continuous_wt(signal, sampling_rate=1000, min_frequency=0.04, max_frequency=
 # Wigner-Ville Distribution
 # =============================================================================
 def wvd(signal, sampling_rate=1000, n_freqbins=None, analytical_signal=True, method="WignerVille"):
-    """Wigner Ville Distribution and Pseudo-Wigner Ville Distribution.
-    """
+    """Wigner Ville Distribution and Pseudo-Wigner Ville Distribution."""
     # Compute the analytical signal
     if analytical_signal:
         signal = scipy.signal.hilbert(signal_detrend(signal))
@@ -240,8 +249,8 @@ def wvd(signal, sampling_rate=1000, n_freqbins=None, analytical_signal=True, met
         fwindows_mpts = len(fwindows) // 2
         windows_length = n_freqbins // 4
         windows_length = windows_length - windows_length % 2 + 1
-        windows = scipy.hamming(windows_length)
-        fwindows[fwindows_mpts + np.arange(- windows_length // 2, windows_length // 2)] = windows
+        windows = np.hamming(windows_length)
+        fwindows[fwindows_mpts + np.arange(-windows_length // 2, windows_length // 2)] = windows
     else:
         fwindows = np.ones(n_freqbins + 1)
         fwindows_mpts = len(fwindows) // 2
@@ -250,19 +259,22 @@ def wvd(signal, sampling_rate=1000, n_freqbins=None, analytical_signal=True, met
 
     # This is discrete frequency (should we return?)
     if n_freqbins % 2 == 0:
-        frequency = np.hstack((np.arange(n_freqbins / 2),
-                               np.arange(-n_freqbins / 2, 0)))
+        frequency = np.hstack((np.arange(n_freqbins / 2), np.arange(-n_freqbins / 2, 0)))
     else:
-        frequency = np.hstack((np.arange((n_freqbins - 1) / 2),
-                               np.arange(-(n_freqbins - 1) / 2, 0)))
+        frequency = np.hstack((np.arange((n_freqbins - 1) / 2), np.arange(-(n_freqbins - 1) / 2, 0)))
     tfr = np.zeros((n_freqbins, time.shape[0]), dtype=complex)  # the time-frequency matrix
 
     tausec = round(n_freqbins / 2.0)
     winlength = tausec - 1
     # taulens: len of tau for each step
-    taulens = np.min(np.c_[np.arange(signal.shape[0]),
-                           signal.shape[0] - np.arange(signal.shape[0]) - 1,
-                           winlength * np.ones(time.shape)], axis=1)
+    taulens = np.min(
+        np.c_[
+            np.arange(signal.shape[0]),
+            signal.shape[0] - np.arange(signal.shape[0]) - 1,
+            winlength * np.ones(time.shape),
+        ],
+        axis=1,
+    )
     conj_signal = np.conj(signal)
     # iterate and compute the wv for each indices
     for idx in range(time.shape[0]):
@@ -271,9 +283,10 @@ def wvd(signal, sampling_rate=1000, n_freqbins=None, analytical_signal=True, met
         indices = np.remainder(n_freqbins + tau, n_freqbins).astype(int)
         tfr[indices, idx] = fwindows[fwindows_mpts + tau] * signal[idx + tau] * conj_signal[idx - tau]
         if (idx < signal.shape[0] - tausec) and (idx >= tausec + 1):
-            tfr[tausec, idx] = fwindows[fwindows_mpts + tausec] * signal[idx + tausec] * \
-                np.conj(signal[idx - tausec]) + \
-                fwindows[fwindows_mpts - tausec] * signal[idx - tausec] * conj_signal[idx + tausec]
+            tfr[tausec, idx] = (
+                fwindows[fwindows_mpts + tausec] * signal[idx + tausec] * np.conj(signal[idx - tausec])
+                + fwindows[fwindows_mpts - tausec] * signal[idx - tausec] * conj_signal[idx + tausec]
+            )
             tfr[tausec, idx] *= 0.5
 
     # Now tfr contains the product of the signal segments and its conjugate.
@@ -292,8 +305,16 @@ def wvd(signal, sampling_rate=1000, n_freqbins=None, analytical_signal=True, met
 # =============================================================================
 
 
-def smooth_pseudo_wvd(signal, sampling_rate=1000, freq_length=None, time_length=None, segment_step=1, nfreqbin=None, window_method="hamming"):
-    """Smoothed Pseudo Wigner Ville Distribution
+def smooth_pseudo_wvd(
+    signal,
+    sampling_rate=1000,
+    freq_length=None,
+    time_length=None,
+    segment_step=1,
+    nfreqbin=None,
+    window_method="hamming",
+):
+    """Smoothed Pseudo Wigner Ville Distribution.
 
     Parameters
     ----------
@@ -326,7 +347,8 @@ def smooth_pseudo_wvd(signal, sampling_rate=1000, freq_length=None, time_length=
     J. M. O' Toole, M. Mesbah, and B. Boashash, (2008),
     "A New Discrete Analytic Signal for Reducing Aliasing in the
      Discrete Wigner-Ville Distribution", IEEE Trans.
-     """
+
+    """
 
     # Define parameters
     N = len(signal)
@@ -339,7 +361,7 @@ def smooth_pseudo_wvd(signal, sampling_rate=1000, freq_length=None, time_length=
 
     # DFT
     signal_fft = np.fft.fft(signal_padded)
-    signal_fft[1: N-1] = signal_fft[1: N-1] * 2
+    signal_fft[1 : N - 1] = signal_fft[1 : N - 1] * 2
     signal_fft[N:] = 0
 
     # Inverse FFT
@@ -391,14 +413,9 @@ def smooth_pseudo_wvd(signal, sampling_rate=1000, freq_length=None, time_length=
     # Calculate pwvd
     for i, t in enumerate(time_array):
         # time shift
-        tau_max = np.min([t + midpt_time - 1,
-                          N - t + midpt_time,
-                          np.round(N / 2.0) - 1,
-                          midpt_freq])
+        tau_max = np.min([t + midpt_time - 1, N - t + midpt_time, np.round(N / 2.0) - 1, midpt_freq])
         # time-lag list
-        tau = np.arange(start=-np.min([midpt_time, N - t]),
-                        stop=np.min([midpt_time, t - 1]) + 1,
-                        dtype='int')
+        tau = np.arange(start=-np.min([midpt_time, N - t]), stop=np.min([midpt_time, t - 1]) + 1, dtype="int")
         time_pts = (midpt_time + tau).astype(int)
         g2 = time_window[time_pts]
         g2 = g2 / np.sum(g2)
@@ -407,9 +424,9 @@ def smooth_pseudo_wvd(signal, sampling_rate=1000, freq_length=None, time_length=
         pwvd[0, i] = np.sum(g2 * signal[signal_pts] * np.conjugate(signal[signal_pts]))
         # other frequencies
         for m in range(int(tau_max)):
-            tau = np.arange(start=-np.min([midpt_time, N - t - m]),
-                            stop=np.min([midpt_time, t - m - 1]) + 1,
-                            dtype='int')
+            tau = np.arange(
+                start=-np.min([midpt_time, N - t - m]), stop=np.min([midpt_time, t - m - 1]) + 1, dtype="int"
+            )
             time_pts = (midpt_time + tau).astype(int)
             g2 = time_window[time_pts]
             g2 = g2 / np.sum(g2)
@@ -425,9 +442,9 @@ def smooth_pseudo_wvd(signal, sampling_rate=1000, freq_length=None, time_length=
         m = np.round(N / 2.0)
 
         if t <= N - m and t >= m + 1 and m <= midpt_freq:
-            tau = np.arange(start=-np.min([midpt_time, N - t - m]),
-                            stop=np.min([midpt_time, t - 1 - m]) + 1,
-                            dtype='int')
+            tau = np.arange(
+                start=-np.min([midpt_time, N - t - m]), stop=np.min([midpt_time, t - 1 - m]) + 1, dtype="int"
+            )
             time_pts = (midpt_time + tau + 1).astype(int)
             g2 = time_window[time_pts]
             g2 = g2 / np.sum(g2)
@@ -450,8 +467,7 @@ def smooth_pseudo_wvd(signal, sampling_rate=1000, freq_length=None, time_length=
 # Plot function
 # =============================================================================
 def plot_timefrequency(z, time, f, signal=None, method="stft"):
-    """Visualize a time-frequency matrix.
-    """
+    """Visualize a time-frequency matrix."""
 
     if method == "stft":
         figure_title = "Short-time Fourier Transform Magnitude"
@@ -459,9 +475,9 @@ def plot_timefrequency(z, time, f, signal=None, method="stft"):
         for i in range(len(time)):
             ax.plot(f, z[:, i], label="Segment" + str(np.arange(len(time))[i] + 1))
         ax.legend()
-        ax.set_title('Signal Spectrogram')
-        ax.set_ylabel('STFT Magnitude')
-        ax.set_xlabel('Frequency (Hz)')
+        ax.set_title("Signal Spectrogram")
+        ax.set_ylabel("STFT Magnitude")
+        ax.set_xlabel("Frequency (Hz)")
 
     elif method == "cwt":
         figure_title = "Continuous Wavelet Transform Magnitude"
@@ -469,8 +485,8 @@ def plot_timefrequency(z, time, f, signal=None, method="stft"):
         figure_title = "Wigner Ville Distrubution Spectrogram"
         fig = plt.figure()
         plt.plot(time, signal)
-        plt.xlabel('Time (sec)')
-        plt.ylabel('Signal')
+        plt.xlabel("Time (sec)")
+        plt.ylabel("Signal")
 
     elif method == "pwvd":
         figure_title = "Pseudo Wigner Ville Distribution Spectrogram"
@@ -479,6 +495,6 @@ def plot_timefrequency(z, time, f, signal=None, method="stft"):
     spec = ax.pcolormesh(time, f, z, cmap=plt.get_cmap("magma"))
     plt.colorbar(spec)
     ax.set_title(figure_title)
-    ax.set_ylabel('Frequency (Hz)')
-    ax.set_xlabel('Time (sec)')
+    ax.set_ylabel("Frequency (Hz)")
+    ax.set_xlabel("Time (sec)")
     return fig

--- a/tests/tests_ecg_findpeaks_MWA.py
+++ b/tests/tests_ecg_findpeaks_MWA.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-import pytest
 
 # Trick to directly access the internal function.
 # Using neurokit2.ecg.ecg_findpeaks._ecg_findpeaks_MWA doesn't
@@ -11,7 +10,5 @@ from neurokit2.ecg.ecg_findpeaks import _ecg_findpeaks_MWA
 
 def test_ecg_findpeaks_MWA():
     np.testing.assert_array_equal(
-        _ecg_findpeaks_MWA(
-            np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=float),
-            3),
-        [0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8])
+        _ecg_findpeaks_MWA(np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=float), 3), [0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8]
+    )

--- a/tests/tests_ecg_findpeaks_MWA.py
+++ b/tests/tests_ecg_findpeaks_MWA.py
@@ -12,6 +12,6 @@ from neurokit2.ecg.ecg_findpeaks import _ecg_findpeaks_MWA
 def test_ecg_findpeaks_MWA():
     np.testing.assert_array_equal(
         _ecg_findpeaks_MWA(
-            np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=np.float),
+            np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=float),
             3),
         [0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8])

--- a/tests/tests_signal.py
+++ b/tests/tests_signal.py
@@ -8,6 +8,7 @@ import scipy.signal
 
 import neurokit2 as nk
 
+
 # =============================================================================
 # Signal
 # =============================================================================
@@ -15,17 +16,11 @@ import neurokit2 as nk
 
 def test_signal_simulate():
     # Warning for nyquist criterion
-    with pytest.warns(
-        nk.misc.NeuroKitWarning,
-        match=r"Skipping requested frequency.*cannot be resolved.*"
-    ):
+    with pytest.warns(nk.misc.NeuroKitWarning, match=r"Skipping requested frequency.*cannot be resolved.*"):
         nk.signal_simulate(sampling_rate=100, frequency=11, silent=False)
 
     # Warning for period duration
-    with pytest.warns(
-        nk.misc.NeuroKitWarning,
-        match=r"Skipping requested frequency.*since its period of.*"
-    ):
+    with pytest.warns(nk.misc.NeuroKitWarning, match=r"Skipping requested frequency.*since its period of.*"):
         nk.signal_simulate(duration=1, frequency=0.1, silent=False)
 
 
@@ -43,8 +38,8 @@ def test_signal_smooth():
 def test_signal_smooth_boxcar():
     signal = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=float)
     np.testing.assert_array_almost_equal(
-        nk.signal_smooth(signal, kernel="boxcar", size=3),
-        [(1+1+2)/3, 2, 3, 4, 5, 6, 7, 8, 9, (9+10+10)/3])
+        nk.signal_smooth(signal, kernel="boxcar", size=3), [(1 + 1 + 2) / 3, 2, 3, 4, 5, 6, 7, 8, 9, (9 + 10 + 10) / 3]
+    )
 
 
 def test_signal_binarize():
@@ -123,7 +118,7 @@ def test_signal_filter():
 
     with pytest.warns(nk.misc.NeuroKitWarning, match=r"The sampling rate is too low.*"):
         with pytest.raises(ValueError):
-            nk.signal_filter(signal, method="bessel", sampling_rate=100 ,highcut=50)
+            nk.signal_filter(signal, method="bessel", sampling_rate=100, highcut=50)
 
     # Generate 10 seconds of signal with 2 Hz oscillation and added 50Hz powerline-noise.
     sampling_rate = 250
@@ -216,8 +211,10 @@ def test_signal_plot():
     signal = nk.signal_simulate(duration=10, sampling_rate=1000)
     nk.signal_plot(signal, sampling_rate=1000)
     fig = plt.gcf()
-    for ax in fig.get_axes():
-        handles, labels = ax.get_legend_handles_labels()
+    axs = fig.get_axes()
+    assert len(axs) == 1
+    ax = axs[0]
+    handles, labels = ax.get_legend_handles_labels()
     assert labels == ["Signal"]
     assert len(labels) == len(handles) == len([signal])
     assert ax.get_xlabel() == "Time (seconds)"
@@ -266,10 +263,12 @@ def test_signal_power():
 
 def test_signal_timefrequency():
 
-    signal = nk.signal_simulate(duration = 50, frequency=5) + 2 * nk.signal_simulate(duration = 50, frequency=20)
+    signal = nk.signal_simulate(duration=50, frequency=5) + 2 * nk.signal_simulate(duration=50, frequency=20)
 
     # short-time fourier transform
-    frequency, time, stft = nk.signal_timefrequency(signal, method="stft", min_frequency=1, max_frequency=50, show=False)
+    frequency, time, stft = nk.signal_timefrequency(
+        signal, method="stft", min_frequency=1, max_frequency=50, show=False
+    )
 
     assert len(frequency) == stft.shape[0]
     assert len(time) == stft.shape[1]
@@ -295,13 +294,13 @@ def test_signal_timefrequency():
     assert np.sum(wvd[indices_freq5]) < np.sum(wvd[indices_freq20])
 
     # pwvd
-    frequency, time, pwvd = nk.signal_timefrequency(signal, method="pwvd",
-                                                    max_frequency=50, show=False)
+    frequency, time, pwvd = nk.signal_timefrequency(signal, method="pwvd", max_frequency=50, show=False)
     assert len(frequency) == pwvd.shape[0]
     assert len(time) == pwvd.shape[1]
     indices_freq5 = np.logical_and(frequency > 3, frequency < 7)
     indices_freq20 = np.logical_and(frequency > 18, frequency < 22)
     assert np.sum(pwvd[indices_freq5]) < np.sum(pwvd[indices_freq20])
+
 
 def test_signal_psd(recwarn):
     warnings.simplefilter("always")
@@ -319,17 +318,10 @@ def test_signal_distort():
     signal = nk.signal_simulate(duration=10, frequency=0.5, sampling_rate=10)
 
     # Warning for nyquist criterion
-    with pytest.warns(
-        nk.misc.NeuroKitWarning,
-        match=r"Skipping requested noise frequency.*cannot be resolved.*"
-    ):
+    with pytest.warns(nk.misc.NeuroKitWarning, match=r"Skipping requested noise frequency.*cannot be resolved.*"):
         nk.signal_distort(signal, sampling_rate=10, noise_amplitude=1, silent=False)
 
     # Warning for period duration
-    with pytest.warns(
-        nk.misc.NeuroKitWarning,
-        match=r"Skipping requested noise frequency.*since its period of.*"
-    ):
+    with pytest.warns(nk.misc.NeuroKitWarning, match=r"Skipping requested noise frequency.*since its period of.*"):
         signal = nk.signal_simulate(duration=1, frequency=1, sampling_rate=10)
         nk.signal_distort(signal, noise_amplitude=1, noise_frequency=0.1, silent=False)
-

--- a/tests/tests_signal.py
+++ b/tests/tests_signal.py
@@ -40,6 +40,13 @@ def test_signal_smooth():
     assert np.allclose(np.std(smooth2), 0.1771, atol=0.0001)
 
 
+def test_signal_smooth_boxcar():
+    signal = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=float)
+    np.testing.assert_array_almost_equal(
+        nk.signal_smooth(signal, kernel="boxcar", size=3),
+        [(1+1+2)/3, 2, 3, 4, 5, 6, 7, 8, 9, (9+10+10)/3])
+
+
 def test_signal_binarize():
 
     signal = np.cos(np.linspace(start=0, stop=20, num=1000))


### PR DESCRIPTION
As noted in https://github.com/neuropsychology/NeuroKit/pull/423, it turns out that the `np.convolve` function used by `signal_smooth` does not outperform a more targeted optimization for the special case of using the uniform boxcar kernel. The best implementation of this special case I could find is `scipy.ndimage.uniform_filter1d`.

This PR adjusts `signal_smooth` to use that function for computing boxcar convolutions. The second commit in this PR just applies the suggested automatic formatting and fixes trivial lint warnings in the affected files.

The results of a quick and simple benchmark of running 1k iterations of boxcar smoothing over various signal length and kernel size combinations with a) the current implementation, b) the `cumsum` based optimization used in e28e7602d96e29ab887d4b09d3c51e78351373fc, and c) the `scipy.ndimage.uniform_filter1d` function:

```
Random signal with 1000 samples:
  Kernel size   3: 0.06 (smooth) vs. 0.01 (mwa) vs. 0.01 (scipy)
  Kernel size   5: 0.08 (smooth) vs. 0.01 (mwa) vs. 0.01 (scipy)
  Kernel size  10: 0.12 (smooth) vs. 0.01 (mwa) vs. 0.01 (scipy)
  Kernel size  20: 0.12 (smooth) vs. 0.01 (mwa) vs. 0.01 (scipy)
  Kernel size  50: 0.12 (smooth) vs. 0.01 (mwa) vs. 0.01 (scipy)
  Kernel size 100: 0.12 (smooth) vs. 0.01 (mwa) vs. 0.01 (scipy)
Random signal with 10000 samples:
  Kernel size   3: 0.28 (smooth) vs. 0.05 (mwa) vs. 0.03 (scipy)
  Kernel size   5: 0.43 (smooth) vs. 0.04 (mwa) vs. 0.03 (scipy)
  Kernel size  10: 0.29 (smooth) vs. 0.04 (mwa) vs. 0.03 (scipy)
  Kernel size  20: 0.29 (smooth) vs. 0.04 (mwa) vs. 0.03 (scipy)
  Kernel size  50: 0.27 (smooth) vs. 0.04 (mwa) vs. 0.03 (scipy)
  Kernel size 100: 0.29 (smooth) vs. 0.04 (mwa) vs. 0.03 (scipy)
Random signal with 100000 samples:
  Kernel size   3: 2.89 (smooth) vs. 1.26 (mwa) vs. 0.85 (scipy)
  Kernel size   5: 4.44 (smooth) vs. 1.26 (mwa) vs. 0.73 (scipy)
  Kernel size  10: 5.48 (smooth) vs. 0.46 (mwa) vs. 0.29 (scipy)
  Kernel size  20: 5.07 (smooth) vs. 0.44 (mwa) vs. 0.24 (scipy)
  Kernel size  50: 5.07 (smooth) vs. 0.42 (mwa) vs. 0.25 (scipy)
  Kernel size 100: 5.10 (smooth) vs. 0.43 (mwa) vs. 0.25 (scipy)
Random signal with 1000000 samples:
  Kernel size   3: 25.63 (smooth) vs. 8.75 (mwa) vs. 5.84 (scipy)
  Kernel size   5: 40.85 (smooth) vs. 8.74 (mwa) vs. 5.82 (scipy)
  Kernel size  10: 78.61 (smooth) vs. 7.95 (mwa) vs. 5.76 (scipy)
  Kernel size  20: 54.24 (smooth) vs. 7.99 (mwa) vs. 5.70 (scipy)
  Kernel size  50: 54.16 (smooth) vs. 7.99 (mwa) vs. 5.70 (scipy)
  Kernel size 100: 53.75 (smooth) vs. 7.95 (mwa) vs. 5.70 (scipy)
```

The `uniform_filter1d` function is the fastest implementation in all of these scenarios. As expected, its runtime is only dependent on the signal length while the current implementation that's based on the more generic `np.convolve` depends also on kernel size.).

<details>
<summary>Benchmark code</summary>

```python
import numpy as np
import scipy.ndimage
import scipy.signal
import timeit

def _signal_smoothing(signal, kernel="boxcar", size=5):

    # Get window.
    size = int(size)
    window = scipy.signal.get_window(kernel, size)
    w = window / window.sum()

    # Extend signal edges to avoid boundary effects.
    x = np.concatenate((signal[0] * np.ones(size), signal, signal[-1] * np.ones(size)))

    # Compute moving average.
    smoothed = scipy.signal.convolve(w, x, mode="same")
    smoothed = smoothed[size:-size]
    return smoothed

def _ecg_findpeaks_MWA(signal, window_size):
    """Based on https://github.com/berndporr/py-ecg-detectors/
    Optimized for vectorized computation.
    """

    sums = np.cumsum(signal)

    # Compute moving average for the first `window_size` elements.
    # The denominator grows until it reaches `window_size`.
    mwa_head = sums[:window_size] / np.arange(1, window_size + 1)

    # Compute moving average for all the remaining elements based on the
    # difference of the cumulative sum across `window_size` elements.
    mwa_tail = (sums[window_size:] - sums[:-window_size]) / window_size

    return np.concatenate([mwa_head, mwa_tail])


signal_size = [1000, 10000, 100000, 1000000]
kernel_size = [3, 5, 10, 20, 50, 100]

for ss in signal_size:
    signal = np.random.default_rng(42).random(size=(ss,))
    print("Random signal with %d samples:" % ss)
    for ks in kernel_size:
        smooth_seconds = timeit.timeit(
            "_signal_smoothing(signal, size=ks)",
            number=1000, globals=locals())
        mwa_seconds = timeit.timeit(
            "_ecg_findpeaks_MWA(signal, ks)",
            number=1000, globals=locals())
        scipy_seconds = timeit.timeit(
            "scipy.ndimage.uniform_filter1d(signal, ks, mode='nearest')",
            number=1000, globals=locals())
        print("  Kernel size %3d: %.2f (smooth) vs. %.2f (mwa) vs. %.2f (scipy)"
              % (ks, smooth_seconds, mwa_seconds, scipy_seconds))
```
</details>

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.