### PR TITLE
Fix rare peak-inside-padding issues in _ecg_findpeaks_kalidas

### DIFF
--- a/neurokit2/ecg/ecg_findpeaks.py
+++ b/neurokit2/ecg/ecg_findpeaks.py
@@ -817,7 +817,7 @@ def _ecg_findpeaks_kalidas(signal, sampling_rate=1000):
     b, a = scipy.signal.butter(3, [f1 * 2, f2 * 2], btype="bandpass")
     filtered_squared = scipy.signal.lfilter(b, a, squared)
 
-    # Drop padding to avoid detecting peaks inside it.
+    # Drop padding to avoid detecting peaks inside it (#456)
     filtered_squared = filtered_squared[:signal_length]
 
     filt_peaks = _ecg_findpeaks_peakdetect(filtered_squared, sampling_rate)

--- a/neurokit2/ecg/ecg_findpeaks.py
+++ b/neurokit2/ecg/ecg_findpeaks.py
@@ -791,6 +791,8 @@ def _ecg_findpeaks_kalidas(signal, sampling_rate=1000):
             " this method to run. Please install it first (`pip install PyWavelets`)."
         ) from import_error
 
+    signal_length = len(signal)
+
     swt_level = 3
     padding = -1
     for i in range(1000):
@@ -814,6 +816,9 @@ def _ecg_findpeaks_kalidas(signal, sampling_rate=1000):
 
     b, a = scipy.signal.butter(3, [f1 * 2, f2 * 2], btype="bandpass")
     filtered_squared = scipy.signal.lfilter(b, a, squared)
+
+    # Drop padding to avoid detecting peaks inside it.
+    filtered_squared = filtered_squared[:signal_length]
 
     filt_peaks = _ecg_findpeaks_peakdetect(filtered_squared, sampling_rate)
 


### PR DESCRIPTION
# Description

Fix rare peak-inside-padding issues in _ecg_findpeaks_kalidas

# Proposed Changes

I occasionally see failures in `kalidas2017` peak detection caused by the algorithm returning peak indices that exceed the length of the input signal.

The cause of this problem is the padding needed by the SWT computation, and the simple fix is to drop the padding after the SWT computation is done.

I can't share the data that triggers this problem, and I couldn't think of an easy way to generate an alternative test case. Thus unfortunately I don't have a test case to go with this change. At least the change itself is very simple, and I've verified it locally with the data I have.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
