### PR TITLE
A parameter lost in `eog_plot`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -339,7 +339,7 @@ Electrooculography (EOG)
     signals, info = nk.eog_process(eog_signal, sampling_rate=100)
 
     # Plot
-    plot = nk.eog_plot(signals, sampling_rate=100)
+    plot = nk.eog_plot(signals, info, sampling_rate=100)
 
 
 .. image:: https://raw.github.com/neuropsychology/NeuroKit/master/docs/readme/README_eog.png


### PR DESCRIPTION
# Description

There is a tiny error in the examples in README of EOG.
A parameter lost in `eog_plot`.

# Proposed Changes

The lost parameter is added.
`plot = nk.eog_plot(signals, sampling_rate=100)` to `plot = nk.eog_plot(signals, info, sampling_rate=100)`

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)