### PR TITLE
fix epochs_end from duration of events

### DIFF
--- a/neurokit2/epochs/epochs_create.py
+++ b/neurokit2/epochs/epochs_create.py
@@ -113,13 +113,13 @@ def epochs_create(
 
     # Create epochs
     if epochs_end == "from_events":
-        epochs_end = list(events["duration"])
+        epochs_end = [i / sampling_rate for i in events["duration"]]
     parameters = listify(
         onset=event_onsets, label=event_labels, condition=event_conditions, start=epochs_start, end=epochs_end
     )
 
     # Find the maximum numbers of samples in an epoch
-    parameters["duration"] = np.array(parameters["end"]) - np.array(parameters["start"])
+    parameters["duration"] = list(np.array(parameters["end"]) - np.array(parameters["start"]))
     epoch_max_duration = int(max((i * sampling_rate for i in parameters["duration"])))
 
     # Extend data by the max samples in epochs * NaN (to prevent non-complete data)


### PR DESCRIPTION
#459 brings to our attention a mistake in `epochs_create()`. The duration information from `events` was not transformed to the correct unit (from samples to seconds), resulting in wrong epochs being created. This PR aims to fix this issue

