### PR TITLE
Add labelling to subepochs

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -12,7 +12,7 @@ Breaking Changes
 New Features
 +++++++++++++
 
-* None
+* Add labelling for interval related features if a dictionary of dataframes is passed
 
 Fixes
 +++++++++++++
@@ -44,7 +44,6 @@ New Features
 	* users can create a smaller sub-epoch within the event-related epoch
 	* the rate-related features of ECG and RSP signals are calculated over the sub-epoch
 	* the remaining features are calculated over the original epoch, not the sub-epoch
-* Add labelling for interval related features if a dictionary of dataframes is passed
 
 Fixes
 +++++++++++++

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -44,6 +44,7 @@ New Features
 	* users can create a smaller sub-epoch within the event-related epoch
 	* the rate-related features of ECG and RSP signals are calculated over the sub-epoch
 	* the remaining features are calculated over the original epoch, not the sub-epoch
+* Add labelling for interval related features if a dictionary of dataframes is passed
 
 Fixes
 +++++++++++++

--- a/neurokit2/ecg/ecg_intervalrelated.py
+++ b/neurokit2/ecg/ecg_intervalrelated.py
@@ -47,15 +47,15 @@ def ecg_intervalrelated(data, sampling_rate=1000):
        ECG_Rate_Mean  HRV_RMSSD  ...
     0      ...
 
-    [1 rows x 55 columns]
+    [1 rows x 58 columns]
     >>>
     >>> epochs = nk.epochs_create(df, events=[0, 15000], sampling_rate=100,
     ...                           epochs_end=150)
     >>> nk.ecg_intervalrelated(epochs) #doctest: +ELLIPSIS
-       ECG_Rate_Mean  HRV_RMSSD ...
-    1      ...
+       Label  ECG_Rate_Mean ...
+    1   ...
 
-    [2 rows x 55 columns]
+    [2 rows x 59 columns]
 
     """
     intervals = {}

--- a/neurokit2/ecg/ecg_intervalrelated.py
+++ b/neurokit2/ecg/ecg_intervalrelated.py
@@ -78,8 +78,8 @@ def ecg_intervalrelated(data, sampling_rate=1000):
         for index in data:
             intervals[index] = {}  # Initialize empty container
 
-            # Format dataframe
-            data[index] = data[index].set_index("Index").drop(["Label"], axis=1)
+            # Add label info
+            intervals[index]['Label'] = data[index]['Label'].iloc[0]
 
             # Rate
             intervals[index] = _ecg_intervalrelated_formatinput(data[index], intervals[index])

--- a/neurokit2/eda/eda_intervalrelated.py
+++ b/neurokit2/eda/eda_intervalrelated.py
@@ -81,9 +81,13 @@ def eda_intervalrelated(data):
         for index in data:
             intervals[index] = {}  # Initialize empty container
 
+            # Add label info
+            intervals[index]['Label'] = data[index]['Label'].iloc[0]
+
             intervals[index] = _eda_intervalrelated_formatinput(
                 data[index], intervals[index]
             )
+                
         eda_intervals = pd.DataFrame.from_dict(intervals, orient="index")
 
     return eda_intervals

--- a/neurokit2/emg/emg_intervalrelated.py
+++ b/neurokit2/emg/emg_intervalrelated.py
@@ -72,6 +72,9 @@ def emg_intervalrelated(data):
         for index in data:
             intervals[index] = {}  # Initialize empty container
 
+            # Add label info
+            intervals[index]['Label'] = data[index]['Label'].iloc[0]
+
             intervals[index] = _emg_intervalrelated_formatinput(data[index], intervals[index])
         emg_intervals = pd.DataFrame.from_dict(intervals, orient="index")
 

--- a/neurokit2/eog/eog_intervalrelated.py
+++ b/neurokit2/eog/eog_intervalrelated.py
@@ -45,9 +45,9 @@ def eog_intervalrelated(data):
     >>> epochs = nk.epochs_create(df, events=[0, 30000], sampling_rate=200,
     ...                           epochs_end=120)
     >>> nk.eog_intervalrelated(epochs) #doctest: +ELLIPSIS
-       EOG_Peaks_N  EOG_Rate_Mean
-    1          ...            ...
-    2          ...            ...
+       Label  EOG_Peaks_N  EOG_Rate_Mean
+    1    ...          ...            ...
+    2    ...          ...            ...
 
     """
     intervals = {}
@@ -64,8 +64,8 @@ def eog_intervalrelated(data):
         for index in data:
             intervals[index] = {}  # Initialize empty container
 
-            # Format dataframe
-            data[index] = data[index].set_index("Index").drop(["Label"], axis=1)
+            # Add label info
+            intervals[index]['Label'] = data[index]['Label'].iloc[0]
 
             # Rate and Blinks quantity
             intervals[index] = _eog_intervalrelated_formatinput(data[index], intervals[index])

--- a/neurokit2/ppg/ppg_intervalrelated.py
+++ b/neurokit2/ppg/ppg_intervalrelated.py
@@ -47,15 +47,15 @@ def ppg_intervalrelated(data, sampling_rate=1000):
        PPG_Rate_Mean  HRV_RMSSD  ...
     0      ...
 
-    [1 rows x 56 columns]
+    [1 rows x 58 columns]
     >>>
     >>> epochs = nk.epochs_create(df, events=[0, 15000], sampling_rate=100,
     ...                           epochs_end=150)
     >>> nk.ppg_intervalrelated(epochs) #doctest: +ELLIPSIS
-       PPG_Rate_Mean  HRV_RMSSD ...
-    1      ...
+       Label  PPG_Rate_Mean ...
+    1   ...
 
-    [2 rows x 56 columns]
+    [2 rows x 59 columns]
 
     """
     intervals = {}
@@ -78,8 +78,8 @@ def ppg_intervalrelated(data, sampling_rate=1000):
         for index in data:
             intervals[index] = {}  # Initialize empty container
 
-            # Format dataframe
-            data[index] = data[index].set_index("Index").drop(["Label"], axis=1)
+            # Add label info
+            intervals[index]['Label'] = data[index]['Label'].iloc[0]
 
             # Rate
             intervals[index] = _ppg_intervalrelated_formatinput(data[index], intervals[index])

--- a/neurokit2/rsp/rsp_intervalrelated.py
+++ b/neurokit2/rsp/rsp_intervalrelated.py
@@ -83,8 +83,8 @@ def rsp_intervalrelated(data, sampling_rate=1000):
         for index in data:
             intervals[index] = {}  # Initialize empty container
 
-            # Format dataframe
-            data[index] = data[index].set_index("Index").drop(["Label"], axis=1)
+            # Add label info
+            intervals[index]['Label'] = data[index]['Label'].iloc[0]
 
             # Rate, Amplitude and Phase
             intervals[index] = _rsp_intervalrelated_formatinput(data[index], sampling_rate, intervals[index])

--- a/tests/tests_ecg.py
+++ b/tests/tests_ecg.py
@@ -276,6 +276,7 @@ def test_ecg_intervalrelated():
     assert features_df.shape[0] == 1  # Number of rows
 
     # Test with dict
+    columns.append('Label')
     epochs = nk.epochs_create(df, events=[0, 15000],
                               sampling_rate=100, epochs_end=150)
     features_dict = nk.ecg_intervalrelated(epochs, sampling_rate=100)

--- a/tests/tests_eda.py
+++ b/tests/tests_eda.py
@@ -257,6 +257,7 @@ def test_eda_intervalrelated():
     assert features_df.shape[0] == 1  # Number of rows
 
     # Test with dict
+    columns.append('Label')
     epochs = nk.epochs_create(df, events=[0, 25300], sampling_rate=100, epochs_end=20)
     features_dict = nk.eda_intervalrelated(epochs)
 

--- a/tests/tests_emg.py
+++ b/tests/tests_emg.py
@@ -137,6 +137,7 @@ def test_emg_intervalrelated():
     assert features_df.shape[0] == 1  # Number of rows
 
     # Test with dict
+    columns.append('Label')
     epochs = nk.epochs_create(emg_signals, events=[0, 20000], sampling_rate=1000, epochs_end=20)
     features_dict = nk.emg_intervalrelated(epochs)
 

--- a/tests/tests_eog.py
+++ b/tests/tests_eog.py
@@ -143,6 +143,7 @@ def test_eog_intervalrelated():
     assert features.shape[0] == 1  # Number of rows
 
     # Test with dict
+    columns.append('Label')
     epochs = nk.epochs_create(eog_signals, events=[5000, 10000, 15000], epochs_start=-0.1, epochs_end=1.9)
     epochs_dict = nk.eog_intervalrelated(epochs)
 

--- a/tests/tests_rsp.py
+++ b/tests/tests_rsp.py
@@ -226,6 +226,7 @@ def test_rsp_intervalrelated():
     assert features_df.shape[0] == 1  # Number of rows
 
     # Test with dict
+    columns.append('Label')
     epochs = nk.epochs_create(df, events=[0, 15000], sampling_rate=100, epochs_end=150)
     features_dict = nk.rsp_intervalrelated(epochs)
 

--- a/tests/tests_rsp.py
+++ b/tests/tests_rsp.py
@@ -226,7 +226,6 @@ def test_rsp_intervalrelated():
     assert features_df.shape[0] == 1  # Number of rows
 
     # Test with dict
-    columns.append('Label')
     epochs = nk.epochs_create(df, events=[0, 15000], sampling_rate=100, epochs_end=150)
     features_dict = nk.rsp_intervalrelated(epochs)
 


### PR DESCRIPTION
The `*_intervalrelated()` functions can either take one whole dataframe as an input:
```
nk.ecg_intervalrelated(df, sampling_rate=100)

Out[506]: 
   ECG_Rate_Mean  HRV_RMSSD  HRV_MeanNN  ...  HRV_RCMSE   HRV_DFA  HRV_CorrDim
0      86.392105  38.837766  694.756381  ...   1.666211  0.717625     1.294291
```
or a **dictionary of dataframes** like so
```
epochs = nk.epochs_create(df, events=[0, 15000], sampling_rate=100, epochs_end=150)
nk.ecg_intervalrelated(epochs)

Out[508]: 
  ECG_Rate_Mean  HRV_RMSSD  ...  HRV_RCMSE   HRV_DFA  HRV_CorrDim
1    86.389814   3.638450  ...   1.456566  0.607610     1.383023
2    86.394396   4.032578  ...   1.834454  0.768419     1.264621
```
I think it's clearer if we append the label of the dataframe (extracted from the epochs input) to the final features output rather than rely on the pandas indexing to tell us which row corresponds to which dataframe as the indexing may be spurious
```
  Label  ECG_Rate_Mean  HRV_RMSSD  ...  HRV_RCMSE   HRV_DFA  HRV_CorrDim
1     1      86.389814   3.638450  ...   1.456566  0.607610     1.383023
2     2      86.394396   4.032578  ...   1.834454  0.768419     1.264621
```

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [x] I have added the newly added features to **News.rst** (if applicable)