### PR TITLE
Fix download error when downloading `mne` datasets

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -18,7 +18,7 @@ New Features
 Fixes
 +++++++++++++
 
-* None
+* Add path argument in `mne_data()` and throw warning to download mne datasets if data folder is not present
 
 
 0.1.3

--- a/neurokit2/eeg/mne_data.py
+++ b/neurokit2/eeg/mne_data.py
@@ -35,11 +35,12 @@ def mne_data(what="raw", path=None):
     old_verbosity_level = mne.set_log_level(verbose="WARNING", return_old_level=True)
 
     if what in ["raw", "filt-0-40_raw"]:
-        try:
-            path = mne.datasets.sample.data_path()
-        except ValueError:
-            raise ValueError("NeuroKit error: the mne sample data folder does not exist. ",
-                             "Please specify a path to download the mne datasets.")
+        if path is None:
+            try:
+                path = mne.datasets.sample.data_path()
+            except ValueError:
+                raise ValueError("NeuroKit error: the mne sample data folder does not exist. ",
+                                 "Please specify a path to download the mne datasets.")
         path += '/MEG/sample/sample_audvis_' + what + '.fif'
         data = mne.io.read_raw_fif(path, preload=True)
         data = data.pick_types(meg=False, eeg=True)

--- a/neurokit2/eeg/mne_data.py
+++ b/neurokit2/eeg/mne_data.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 
-def mne_data(what="raw"):
+def mne_data(what="raw", path=None):
     """Utility function to easily access MNE datasets
 
     Parameters
     -----------
     what : str
         Can be 'raw' or 'filt-0-40_raw' (a filtered version).
+    path : str
+        Defaults to None, assuming that the MNE data folder already exists. If not,
+        specify the directory to download the folder.
 
     Returns
     -------
@@ -32,7 +35,11 @@ def mne_data(what="raw"):
     old_verbosity_level = mne.set_log_level(verbose="WARNING", return_old_level=True)
 
     if what in ["raw", "filt-0-40_raw"]:
-        path = mne.datasets.sample.data_path()
+        try:
+            path = mne.datasets.sample.data_path()
+        except ValueError:
+            raise ValueError("NeuroKit error: the mne sample data folder does not exist. ",
+                             "Please specify a path to download the mne datasets.")
         path += '/MEG/sample/sample_audvis_' + what + '.fif'
         data = mne.io.read_raw_fif(path, preload=True)
         data = data.pick_types(meg=False, eeg=True)


### PR DESCRIPTION
Let users know to + have the option to specify `path` argument if the mne data folder is not present (where the data is then downloaded into this path) 

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [ ] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [ ] My PR is targetted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)