### PR TITLE
Format `complexity` outputs

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -2,6 +2,25 @@ News
 =====
 
 
+0.1.5
+-------------------
+
+Breaking Changes
++++++++++++++++++
+
+* `complexity_lempelziv()`, `fractal_higuchi()`, `fractal_katz()`, `fractal_correlation()`, `fractal_dfa()`, `entropy_multiscale()`, `entropy_shannon()`, `entropy_approximate()`, `entropy_fuzzy()`, `entropy_sample()` now return a tuple consisting of the complexity index, and a dictionary comprising of the different parameters specific to the measure. For `fractal_katz()` and `entropy_shannon()`, the parameters dictionary is empty.
+
+
+New Features
++++++++++++++
+
+* None
+
+Fixes
++++++++++++++
+
+* None
+
 
 0.1.4.1
 -------------------

--- a/neurokit2/complexity/complexity_lempelziv.py
+++ b/neurokit2/complexity/complexity_lempelziv.py
@@ -22,8 +22,11 @@ def complexity_lempelziv(signal, threshold="median", normalize=True):
 
     Returns
     ----------
-    float
+    lzc : float
         Lempel Ziv Complexity.
+    parameters : dict
+        A dictionary containing additional information regarding the parameters used
+        to compute Lempel Ziv Complexity.
 
     Examples
     ----------
@@ -31,7 +34,7 @@ def complexity_lempelziv(signal, threshold="median", normalize=True):
     >>>
     >>> signal = nk.signal_simulate(duration=2, frequency=5, noise=10)
     >>>
-    >>> lzc = nk.complexity_lempelziv(signal, threshold="median")
+    >>> lzc, parameters = nk.complexity_lempelziv(signal, threshold="median")
     >>> lzc #doctest: +SKIP
 
     References
@@ -84,7 +87,10 @@ def complexity_lempelziv(signal, threshold="median", normalize=True):
     if normalize is True:
         complexity = _complexity_lempelziv_normalize(p_seq, complexity)
 
-    return {'LZC': complexity}
+    parameters = {'threshold': threshold,
+                  'normalize': normalize}
+
+    return complexity, parameters
 
 
 def _complexity_lempelziv_binarize(signal, threshold="median"):

--- a/neurokit2/complexity/complexity_lempelziv.py
+++ b/neurokit2/complexity/complexity_lempelziv.py
@@ -84,7 +84,7 @@ def complexity_lempelziv(signal, threshold="median", normalize=True):
     if normalize is True:
         complexity = _complexity_lempelziv_normalize(p_seq, complexity)
 
-    return complexity
+    return {'LZC': complexity}
 
 
 def _complexity_lempelziv_binarize(signal, threshold="median"):

--- a/neurokit2/complexity/complexity_optimize.py
+++ b/neurokit2/complexity/complexity_optimize.py
@@ -273,7 +273,7 @@ def _complexity_r(signal, delay=None, dimension=None):
     r_range = modulator * np.std(signal, ddof=1)
     ApEn = np.zeros_like(r_range)
     for i, r in enumerate(r_range):
-        ApEn[i] = entropy_approximate(signal, delay=delay, dimension=dimension, r=r_range[i])
+        ApEn[i] = entropy_approximate(signal, delay=delay, dimension=dimension, r=r_range[i])["ApEn"]
     r = r_range[np.argmax(ApEn)]
 
     return r_range, ApEn, r

--- a/neurokit2/complexity/complexity_optimize.py
+++ b/neurokit2/complexity/complexity_optimize.py
@@ -273,7 +273,7 @@ def _complexity_r(signal, delay=None, dimension=None):
     r_range = modulator * np.std(signal, ddof=1)
     ApEn = np.zeros_like(r_range)
     for i, r in enumerate(r_range):
-        ApEn[i] = entropy_approximate(signal, delay=delay, dimension=dimension, r=r_range[i])["ApEn"]
+        ApEn[i] = entropy_approximate(signal, delay=delay, dimension=dimension, r=r_range[i])[0]
     r = r_range[np.argmax(ApEn)]
 
     return r_range, ApEn, r

--- a/neurokit2/complexity/complexity_r.py
+++ b/neurokit2/complexity/complexity_r.py
@@ -74,7 +74,7 @@ def _optimize_r(signal, delay=None, dimension=None, show=False):
 
     ApEn = np.zeros_like(r_range)
     for i, r in enumerate(r_range):
-        ApEn[i] = entropy_approximate(signal, delay=delay, dimension=dimension, r=r_range[i])["ApEn"]
+        ApEn[i] = entropy_approximate(signal, delay=delay, dimension=dimension, r=r_range[i])[0]
 
     r = r_range[np.argmax(ApEn)]
 

--- a/neurokit2/complexity/complexity_r.py
+++ b/neurokit2/complexity/complexity_r.py
@@ -74,7 +74,7 @@ def _optimize_r(signal, delay=None, dimension=None, show=False):
 
     ApEn = np.zeros_like(r_range)
     for i, r in enumerate(r_range):
-        ApEn[i] = entropy_approximate(signal, delay=delay, dimension=dimension, r=r_range[i])
+        ApEn[i] = entropy_approximate(signal, delay=delay, dimension=dimension, r=r_range[i])["ApEn"]
 
     r = r_range[np.argmax(ApEn)]
 

--- a/neurokit2/complexity/entropy_approximate.py
+++ b/neurokit2/complexity/entropy_approximate.py
@@ -104,6 +104,4 @@ def entropy_approximate(signal, delay=1, dimension=2, r="default", corrected=Fal
             else:
                 vector_similarity[i] = np.log(correction)
 
-        apen = -np.mean(vector_similarity)
-
-    return apen
+    return {'ApEn': -np.mean(vector_similarity)}

--- a/neurokit2/complexity/entropy_approximate.py
+++ b/neurokit2/complexity/entropy_approximate.py
@@ -104,4 +104,6 @@ def entropy_approximate(signal, delay=1, dimension=2, r="default", corrected=Fal
             else:
                 vector_similarity[i] = np.log(correction)
 
-    return {'ApEn': -np.mean(vector_similarity)}
+        apen = -np.mean(vector_similarity)
+
+    return {'ApEn': apen}

--- a/neurokit2/complexity/entropy_approximate.py
+++ b/neurokit2/complexity/entropy_approximate.py
@@ -45,18 +45,20 @@ def entropy_approximate(signal, delay=1, dimension=2, r="default", corrected=Fal
 
     Returns
     ----------
-    float
+    apen : float
         The approximate entropy as float value.
-
+    parameters : dict
+        A dictionary containing additional information regarding the parameters used
+        to compute approximate entropy.
 
     Examples
     ----------
     >>> import neurokit2 as nk
     >>>
     >>> signal = nk.signal_simulate(duration=2, frequency=5)
-    >>> entropy1 = nk.entropy_approximate(signal)
+    >>> entropy1, parameters = nk.entropy_approximate(signal)
     >>> entropy1 #doctest: +SKIP
-    >>> entropy2 = nk.entropy_approximate(signal, corrected=True)
+    >>> entropy2, parameters = nk.entropy_approximate(signal, corrected=True)
     >>> entropy2 #doctest: +SKIP
 
 
@@ -106,4 +108,9 @@ def entropy_approximate(signal, delay=1, dimension=2, r="default", corrected=Fal
 
         apen = -np.mean(vector_similarity)
 
-    return {'ApEn': apen}
+    parameters = {'tolerance': r,
+                  'embedding_dimension': dimension,
+                  'tau': delay,
+                  'corrected': corrected}
+
+    return apen, parameters

--- a/neurokit2/complexity/entropy_fuzzy.py
+++ b/neurokit2/complexity/entropy_fuzzy.py
@@ -49,4 +49,4 @@ def entropy_fuzzy(signal, delay=1, dimension=2, r="default", **kwargs):
     r = _get_r(signal, r=r, dimension=dimension)
     phi = _phi(signal, delay=delay, dimension=dimension, r=r, approximate=False, fuzzy=True, **kwargs)
 
-    return _phi_divide(phi)
+    return {'FuzzyEn': _phi_divide(phi)}

--- a/neurokit2/complexity/entropy_fuzzy.py
+++ b/neurokit2/complexity/entropy_fuzzy.py
@@ -30,8 +30,11 @@ def entropy_fuzzy(signal, delay=1, dimension=2, r="default", **kwargs):
 
     Returns
     ----------
-    float
+    fuzzyen : float
         The fuzzy entropy as float value.
+    parameters : dict
+        A dictionary containing additional information regarding the parameters used
+        to compute fuzzy entropy.
 
     See Also
     --------
@@ -42,11 +45,17 @@ def entropy_fuzzy(signal, delay=1, dimension=2, r="default", **kwargs):
     >>> import neurokit2 as nk
     >>>
     >>> signal = nk.signal_simulate(duration=2, frequency=5)
-    >>> entropy = nk.entropy_fuzzy(signal)
+    >>> entropy, parameters = nk.entropy_fuzzy(signal)
     >>> entropy #doctest: +SKIP
 
     """
     r = _get_r(signal, r=r, dimension=dimension)
     phi = _phi(signal, delay=delay, dimension=dimension, r=r, approximate=False, fuzzy=True, **kwargs)
 
-    return {'FuzzyEn': _phi_divide(phi)}
+    fuzzyen =  _phi_divide(phi)
+
+    parameters = {'tolerance': r,
+                  'embedding_dimension': dimension,
+                  'tau': delay}
+
+    return fuzzyen, parameters

--- a/neurokit2/complexity/entropy_multiscale.py
+++ b/neurokit2/complexity/entropy_multiscale.py
@@ -109,10 +109,10 @@ def entropy_multiscale(
         **kwargs
     )
 
-    if composite:
-        key = 'CMSE'
-    elif refined:
+    if refined:
         key = 'RCMSE'
+    elif composite:
+        key = 'CMSE'
     else:
         key = 'MSE'
 
@@ -169,7 +169,7 @@ def _entropy_multiscale_mse(signal, tau, dimension, r, fuzzy, **kwargs):
     if len(y) < 10 ** dimension:  # Compute only if enough values (Liu et al., 2012)
         return np.nan
 
-    return entropy_sample(y, delay=1, dimension=dimension, r=r, fuzzy=fuzzy, **kwargs)
+    return entropy_sample(y, delay=1, dimension=dimension, r=r, fuzzy=fuzzy, **kwargs)["SampEn"]
 
 
 def _entropy_multiscale_cmse(signal, tau, dimension, r, fuzzy, **kwargs):
@@ -179,7 +179,7 @@ def _entropy_multiscale_cmse(signal, tau, dimension, r, fuzzy, **kwargs):
 
     mse_y = np.full(len(y), np.nan)
     for i in np.arange(len(y)):
-        mse_y[i] = entropy_sample(y[i, :], delay=1, dimension=dimension, r=r, fuzzy=fuzzy, **kwargs)
+        mse_y[i] = entropy_sample(y[i, :], delay=1, dimension=dimension, r=r, fuzzy=fuzzy, **kwargs)["SampEn"]
 
     return np.mean(mse_y)
 

--- a/neurokit2/complexity/entropy_multiscale.py
+++ b/neurokit2/complexity/entropy_multiscale.py
@@ -50,10 +50,13 @@ def entropy_multiscale(
 
     Returns
     ----------
-    float
+    mse : float
         The point-estimate of multiscale entropy (MSE) as a float value corresponding to the area under
         the MSE values curvee, which is essentially the sum of sample entropy values over the range of
         scale factors.
+    parameters : dict
+        A dictionary containing additional information regarding the parameters used
+        to compute multiscale entropy.
 
     See Also
     --------
@@ -64,11 +67,11 @@ def entropy_multiscale(
     >>> import neurokit2 as nk
     >>>
     >>> signal = nk.signal_simulate(duration=2, frequency=5)
-    >>> entropy1 = nk.entropy_multiscale(signal, show=True)
+    >>> entropy1, parameters = nk.entropy_multiscale(signal, show=True)
     >>> entropy1 #doctest: +SKIP
-    >>> entropy2 = nk.entropy_multiscale(signal, show=True, composite=True)
+    >>> entropy2, parameters = nk.entropy_multiscale(signal, show=True, composite=True)
     >>> entropy2 #doctest: +SKIP
-    >>> entropy3 = nk.entropy_multiscale(signal, show=True, refined=True)
+    >>> entropy3, parameters = nk.entropy_multiscale(signal, show=True, refined=True)
     >>> entropy3 #doctest: +SKIP
 
 
@@ -97,7 +100,7 @@ def entropy_multiscale(
 
     """
 
-    value = _entropy_multiscale(
+    mse = _entropy_multiscale(
         signal,
         scale=scale,
         dimension=dimension,
@@ -119,7 +122,12 @@ def entropy_multiscale(
     if fuzzy:
         key = 'Fuzzy' + key
 
-    return {key: value}
+    parameters = {'tolerance': _get_r(signal, r=r),
+                  'embedding_dimension': dimension,
+                  'scale': _get_scale(signal, scale=scale, dimension=dimension),
+                  'version': key}
+
+    return mse, parameters
 
 
 # =============================================================================
@@ -169,7 +177,7 @@ def _entropy_multiscale_mse(signal, tau, dimension, r, fuzzy, **kwargs):
     if len(y) < 10 ** dimension:  # Compute only if enough values (Liu et al., 2012)
         return np.nan
 
-    return entropy_sample(y, delay=1, dimension=dimension, r=r, fuzzy=fuzzy, **kwargs)["SampEn"]
+    return entropy_sample(y, delay=1, dimension=dimension, r=r, fuzzy=fuzzy, **kwargs)[0]
 
 
 def _entropy_multiscale_cmse(signal, tau, dimension, r, fuzzy, **kwargs):
@@ -179,7 +187,7 @@ def _entropy_multiscale_cmse(signal, tau, dimension, r, fuzzy, **kwargs):
 
     mse_y = np.full(len(y), np.nan)
     for i in np.arange(len(y)):
-        mse_y[i] = entropy_sample(y[i, :], delay=1, dimension=dimension, r=r, fuzzy=fuzzy, **kwargs)["SampEn"]
+        mse_y[i] = entropy_sample(y[i, :], delay=1, dimension=dimension, r=r, fuzzy=fuzzy, **kwargs)[0]
 
     return np.mean(mse_y)
 

--- a/neurokit2/complexity/entropy_multiscale.py
+++ b/neurokit2/complexity/entropy_multiscale.py
@@ -96,7 +96,8 @@ def entropy_multiscale(
       anesthesia during surgery. Entropy, 14(6), 978-992.
 
     """
-    return _entropy_multiscale(
+
+    value = _entropy_multiscale(
         signal,
         scale=scale,
         dimension=dimension,
@@ -107,6 +108,18 @@ def entropy_multiscale(
         show=show,
         **kwargs
     )
+
+    if composite:
+        key = 'CMSE'
+    elif refined:
+        key = 'RCMSE'
+    else:
+        key = 'MSE'
+
+    if fuzzy:
+        key = 'Fuzzy' + key
+
+    return {key: value}
 
 
 # =============================================================================

--- a/neurokit2/complexity/entropy_sample.py
+++ b/neurokit2/complexity/entropy_sample.py
@@ -49,4 +49,4 @@ def entropy_sample(signal, delay=1, dimension=2, r="default", **kwargs):
     r = _get_r(signal, r=r, dimension=dimension)
     phi = _phi(signal, delay=delay, dimension=dimension, r=r, approximate=False, **kwargs)
 
-    return _phi_divide(phi)
+    return {'SampEn': _phi_divide(phi)}

--- a/neurokit2/complexity/entropy_sample.py
+++ b/neurokit2/complexity/entropy_sample.py
@@ -34,19 +34,28 @@ def entropy_sample(signal, delay=1, dimension=2, r="default", **kwargs):
 
     Returns
     ----------
-    float
+    sampen : float
         The sample entropy as float value.
+    parameters : dict
+        A dictionary containing additional information regarding the parameters used
+        to compute sample entropy.
 
     Examples
     ----------
     >>> import neurokit2 as nk
     >>>
     >>> signal = nk.signal_simulate(duration=2, frequency=5)
-    >>> entropy = nk.entropy_sample(signal)
+    >>> entropy, parameters = nk.entropy_sample(signal)
     >>> entropy #doctest: +SKIP
 
     """
     r = _get_r(signal, r=r, dimension=dimension)
     phi = _phi(signal, delay=delay, dimension=dimension, r=r, approximate=False, **kwargs)
 
-    return {'SampEn': _phi_divide(phi)}
+    sampen = _phi_divide(phi)
+
+    parameters = {'tolerance': r,
+                  'embedding_dimension': dimension,
+                  'tau': delay}
+
+    return sampen, parameters

--- a/neurokit2/complexity/entropy_shannon.py
+++ b/neurokit2/complexity/entropy_shannon.py
@@ -20,8 +20,11 @@ def entropy_shannon(signal):
 
     Returns
     ----------
-    float
+    shanen : float
         The Shannon entropy as float value.
+    parameters : dict
+        A dictionary containing additional information regarding the parameters used
+        to compute Shannon entropy (empty for now).
 
     See Also
     --------
@@ -32,7 +35,7 @@ def entropy_shannon(signal):
     >>> import neurokit2 as nk
     >>>
     >>> signal = nk.signal_simulate(duration=2, frequency=5)
-    >>> entropy = nk.entropy_shannon(signal)
+    >>> entropy, parameters = nk.entropy_shannon(signal)
     >>> entropy #doctest: +SKIP
 
 
@@ -67,4 +70,6 @@ def entropy_shannon(signal):
         shannon_entropy += freq * np.log2(freq)
     shannon_entropy = -shannon_entropy
 
-    return {'ShanEn': shannon_entropy}
+    parameters = {}
+
+    return shannon_entropy, parameters

--- a/neurokit2/complexity/entropy_shannon.py
+++ b/neurokit2/complexity/entropy_shannon.py
@@ -67,4 +67,4 @@ def entropy_shannon(signal):
         shannon_entropy += freq * np.log2(freq)
     shannon_entropy = -shannon_entropy
 
-    return shannon_entropy
+    return {'ShanEn': shannon_entropy}

--- a/neurokit2/complexity/fractal_correlation.py
+++ b/neurokit2/complexity/fractal_correlation.py
@@ -9,7 +9,8 @@ from .complexity_embedding import complexity_embedding
 def fractal_correlation(signal, delay=1, dimension=2, r=64, show=False):
     """Correlation Dimension.
 
-    Python implementation of the Correlation Dimension D2 of a signal.
+    Python implementation of the Correlation Dimension CD (sometimes
+    referred to as D2) of a signal.
 
     This function can be called either via ``fractal_correlation()`` or ``complexity_d2()``.
 
@@ -34,8 +35,11 @@ def fractal_correlation(signal, delay=1, dimension=2, r=64, show=False):
 
     Returns
     ----------
-    D2 : float
-        The correlation dimension D2.
+    cd : float
+        The correlation dimension.
+    parameters : dict
+        A dictionary containing additional information regarding the parameters used
+        to compute the correlation dimension.
 
     Examples
     ----------
@@ -43,16 +47,16 @@ def fractal_correlation(signal, delay=1, dimension=2, r=64, show=False):
     >>>
     >>> signal = nk.signal_simulate(duration=2, frequency=5)
     >>>
-    >>> fractal1 = nk.fractal_correlation(signal, r="nolds", show=True)
+    >>> fractal1, parameters = nk.fractal_correlation(signal, r="nolds", show=True)
     >>> fractal1 #doctest: +SKIP
-    >>> fractal2 = nk.fractal_correlation(signal, r=32, show=True)
+    >>> fractal2, parameters = nk.fractal_correlation(signal, r=32, show=True)
     >>> fractal2 #doctest: +SKIP
     >>>
     >>> signal = nk.rsp_simulate(duration=120, sampling_rate=50)
     >>>
-    >>> fractal3 = nk.fractal_correlation(signal, r="nolds", show=True)
+    >>> fractal3, parameters = nk.fractal_correlation(signal, r="nolds", show=True)
     >>> fractal3 #doctest: +SKIP
-    >>> fractal4 = nk.fractal_correlation(signal, r=32, show=True)
+    >>> fractal4, parameters = nk.fractal_correlation(signal, r=32, show=True)
     >>> fractal4 #doctest: +SKIP
 
 
@@ -84,12 +88,16 @@ def fractal_correlation(signal, delay=1, dimension=2, r=64, show=False):
     if len(corr) == 0:
         return np.nan
     else:
-        d2 = np.polyfit(np.log2(r_vals), np.log2(corr), 1)
+        cd = np.polyfit(np.log2(r_vals), np.log2(corr), 1)
 
     if show is True:
-        _fractal_correlation_plot(r_vals, corr, d2)
+        _fractal_correlation_plot(r_vals, corr, cd)
 
-    return {'CD': d2[0]}
+    parameters = {'embedding_dimension': dimension,
+                  'tau': delay,
+                  'radiuses': r_vals}
+
+    return cd[0], parameters
 
 
 # =============================================================================

--- a/neurokit2/complexity/fractal_correlation.py
+++ b/neurokit2/complexity/fractal_correlation.py
@@ -89,7 +89,7 @@ def fractal_correlation(signal, delay=1, dimension=2, r=64, show=False):
     if show is True:
         _fractal_correlation_plot(r_vals, corr, d2)
 
-    return d2[0]
+    return {'CD': d2[0]}
 
 
 # =============================================================================

--- a/neurokit2/complexity/fractal_dfa.py
+++ b/neurokit2/complexity/fractal_dfa.py
@@ -69,11 +69,18 @@ def fractal_dfa(signal, windows="default", overlap=True, integrate=True,
 
     Returns
     ----------
-    dfa : dict
-        If `multifractal` is False, the dictionary contains q value, a series of windows, fluctuations of each window and the
-        slopes value of the log2(windows) versus log2(fluctuations) plot. If `multifractal` is True, the dictionary
-        additionally contains the parameters of the singularity spectrum (scaling exponents, singularity dimension, singularity
-        strength; see `singularity_spectrum()` for more information).
+    dfa : float or np.array
+        One DFA value if `multifractal` is False, and an array of DFA values if
+        `multifractal` is True.
+    parameters : dict
+        A dictionary containing additional information regarding the parameters used
+        to compute DFA. If `multifractal` is False, the dictionary contains q value, a
+        series of windows, fluctuations of each window and the
+        slopes value of the log2(windows) versus log2(fluctuations) plot. If
+        `multifractal` is True, the dictionary additionally contains the
+        parameters of the singularity spectrum (scaling exponents, singularity dimension,
+        singularity strength; see `singularity_spectrum()` for more information).
+
 
 
     Examples
@@ -82,9 +89,9 @@ def fractal_dfa(signal, windows="default", overlap=True, integrate=True,
     >>> import numpy as np
     >>>
     >>> signal = nk.signal_simulate(duration=10, noise=0.05)
-    >>> dfa1 = nk.fractal_dfa(signal, show=True)
+    >>> dfa1, parameters = nk.fractal_dfa(signal, show=True)
     >>> dfa1 #doctest: +SKIP
-    >>> dfa2 = nk.fractal_mfdfa(signal, q=np.arange(-5, 6), show=True)
+    >>> dfa2, parameters = nk.fractal_mfdfa(signal, q=np.arange(-5, 6), show=True)
     >>> dfa2 #doctest: +SKIP
 
 
@@ -136,17 +143,18 @@ def fractal_dfa(signal, windows="default", overlap=True, integrate=True,
         return np.nan
 
     slopes = _slopes(windows, fluctuations, q)
-    out = {'q' : q[:, 0],
-           'windows' : windows,
-           'fluctuations' : fluctuations,
-           'slopes' : slopes}
+    if len(slopes) == 1:
+        slopes = slopes[0]
+    parameters = {'q' : q[:, 0],
+                  'windows' : windows,
+                  'fluctuations' : fluctuations}
 
     if multifractal is True:
         singularity = singularity_spectrum(windows=windows,
                                            fluctuations=fluctuations,
                                            q=q,
                                            slopes=slopes)
-        out.update(singularity)
+        parameters.update(singularity)
 
     # Plot if show is True.
     if show is True:
@@ -155,16 +163,16 @@ def fractal_dfa(signal, windows="default", overlap=True, integrate=True,
                                fluctuations=fluctuations,
                                multifractal=multifractal,
                                q=q,
-                               tau=out['tau'],
-                               hq=out['hq'],
-                               Dq=out['Dq'])
+                               tau=parameters['tau'],
+                               hq=parameters['hq'],
+                               Dq=parameters['Dq'])
         else:
             _fractal_dfa_plot(windows=windows,
                               fluctuations=fluctuations,
                               multifractal=multifractal,
                               q=q)
 
-    return out
+    return slopes, parameters
 
 # =============================================================================
 # Utilities

--- a/neurokit2/complexity/fractal_higuchi.py
+++ b/neurokit2/complexity/fractal_higuchi.py
@@ -90,7 +90,8 @@ def fractal_higuchi(signal, kmax="default", show=False):
             ax_kmax = fig.add_subplot(spec[1, 0])
             _fractal_higuchi_optimal_k_plot(k_range, slope_values, k_max, ax=ax_kmax)
 
-    return slope
+    return {'HFD': slope,
+            'k_max': k_max}
 
 
 # =============================================================================

--- a/neurokit2/complexity/fractal_higuchi.py
+++ b/neurokit2/complexity/fractal_higuchi.py
@@ -91,7 +91,7 @@ def fractal_higuchi(signal, kmax="default", show=False):
             _fractal_higuchi_optimal_k_plot(k_range, slope_values, k_max, ax=ax_kmax)
 
     return {'HFD': slope,
-            'k_max': k_max}
+            'kmax': k_max}
 
 
 # =============================================================================

--- a/neurokit2/complexity/fractal_higuchi.py
+++ b/neurokit2/complexity/fractal_higuchi.py
@@ -31,8 +31,11 @@ def fractal_higuchi(signal, kmax="default", show=False):
 
     Returns
     ----------
-    slope
+    slope : float
         Higuchi's fractal dimension.
+    parameters : dict
+        A dictionary containing additional information regarding the parameters used
+        to compute Higuchi's fractal dimension.
 
     Examples
     ----------
@@ -40,9 +43,9 @@ def fractal_higuchi(signal, kmax="default", show=False):
     >>>
     >>> signal = nk.data('bio_eventrelated_100hz')['ECG']
     >>>
-    >>> hfd = nk.fractal_higuchi(signal, kmax=5, show=True)
+    >>> hfd, parameters = nk.fractal_higuchi(signal, kmax=5, show=True)
     >>> hfd #doctest: +SKIP
-    >>> hfd = nk.fractal_higuchi(signal, kmax="default", show=True)
+    >>> hfd, parameters = nk.fractal_higuchi(signal, kmax="default", show=True)
     >>> hfd #doctest: +SKIP
 
     Reference
@@ -90,8 +93,9 @@ def fractal_higuchi(signal, kmax="default", show=False):
             ax_kmax = fig.add_subplot(spec[1, 0])
             _fractal_higuchi_optimal_k_plot(k_range, slope_values, k_max, ax=ax_kmax)
 
-    return {'HFD': slope,
-            'kmax': k_max}
+    parameters = {'kmax': k_max}
+
+    return slope, parameters
 
 
 # =============================================================================

--- a/neurokit2/complexity/fractal_katz.py
+++ b/neurokit2/complexity/fractal_katz.py
@@ -49,4 +49,4 @@ def fractal_katz(signal):
 
     kfd = np.log10(length/a) / (np.log10(d/a))
 
-    return kfd
+    return {'KFD': kfd}

--- a/neurokit2/complexity/fractal_katz.py
+++ b/neurokit2/complexity/fractal_katz.py
@@ -19,8 +19,11 @@ def fractal_katz(signal):
 
     Returns
     -------
-    float
+    kfd : float
         Katz's fractal dimension.
+    parameters : dict
+        A dictionary containing additional information regarding the parameters used
+        to compute Katz's fractal dimension (empty for now).
 
     Examples
     ----------
@@ -49,4 +52,6 @@ def fractal_katz(signal):
 
     kfd = np.log10(length/a) / (np.log10(d/a))
 
-    return {'KFD': kfd}
+    parameters = {}
+
+    return kfd, parameters

--- a/neurokit2/hrv/hrv_nonlinear.py
+++ b/neurokit2/hrv/hrv_nonlinear.py
@@ -256,18 +256,18 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False, **kwargs):
 
     # Complexity
     r = 0.2 * np.std(rri, ddof=1)
-    out["ApEn"] = entropy_approximate(rri, delay=1, dimension=2, r=r)
-    out["SampEn"] = entropy_sample(rri, delay=1, dimension=2, r=r)
-    out["ShanEn"] = entropy_shannon(rri)
-    out["FuzzyEn"] = entropy_fuzzy(rri, delay=1, dimension=2, r=r)
-    out["MSE"] = entropy_multiscale(rri, dimension=2, r=r, composite=False, refined=False)
-    out["CMSE"] = entropy_multiscale(rri, dimension=2, r=r, composite=True, refined=False)
-    out["RCMSE"] = entropy_multiscale(rri, dimension=2, r=r, composite=True, refined=True)
+    out.update(entropy_approximate(rri, delay=1, dimension=2, r=r))
+    out.update(entropy_sample(rri, delay=1, dimension=2, r=r))
+    out.update(entropy_shannon(rri))
+    out.update(entropy_fuzzy(rri, delay=1, dimension=2, r=r))
+    out.update(entropy_multiscale(rri, dimension=2, r=r, composite=False, refined=False))
+    out.update(entropy_multiscale(rri, dimension=2, r=r, composite=True, refined=False))
+    out.update(entropy_multiscale(rri, dimension=2, r=r, composite=True, refined=True))
 
-    out["CD"] = fractal_correlation(rri, delay=1, dimension=2, **kwargs)
-    out["HFD"] = fractal_higuchi(rri, **kwargs)
-    out["KFD"] = fractal_katz(rri)
-    out["LZC"] = complexity_lempelziv(rri, **kwargs)
+    out.update(fractal_correlation(rri, delay=1, dimension=2, **kwargs))
+    out.update(fractal_higuchi(rri, **kwargs))
+    out.update(fractal_katz(rri))
+    out.update(complexity_lempelziv(rri, **kwargs))
 
     if show:
         _hrv_nonlinear_show(rri, out)

--- a/neurokit2/hrv/hrv_nonlinear.py
+++ b/neurokit2/hrv/hrv_nonlinear.py
@@ -256,18 +256,18 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False, **kwargs):
 
     # Complexity
     r = 0.2 * np.std(rri, ddof=1)
-    out.update(entropy_approximate(rri, delay=1, dimension=2, r=r))
-    out.update(entropy_sample(rri, delay=1, dimension=2, r=r))
-    out.update(entropy_shannon(rri))
-    out.update(entropy_fuzzy(rri, delay=1, dimension=2, r=r))
-    out.update(entropy_multiscale(rri, dimension=2, r=r, composite=False, refined=False))
-    out.update(entropy_multiscale(rri, dimension=2, r=r, composite=True, refined=False))
-    out.update(entropy_multiscale(rri, dimension=2, r=r, composite=True, refined=True))
+    out["ApEn"] = entropy_approximate(rri, delay=1, dimension=2, r=r)[0]
+    out["SampEn"] = entropy_sample(rri, delay=1, dimension=2, r=r)[0]
+    out["ShanEn"] = entropy_shannon(rri)[0]
+    out["FuzzyEn"] = entropy_fuzzy(rri, delay=1, dimension=2, r=r)[0]
+    out["MSE"] = entropy_multiscale(rri, dimension=2, r=r, composite=False, refined=False)[0]
+    out["CMSE"] = entropy_multiscale(rri, dimension=2, r=r, composite=True, refined=False)[0]
+    out["RCMSE"] = entropy_multiscale(rri, dimension=2, r=r, composite=True, refined=True)[0]
 
-    out.update(fractal_correlation(rri, delay=1, dimension=2, **kwargs))
-    out.update(fractal_higuchi(rri, **kwargs))
-    out.update(fractal_katz(rri))
-    out.update(complexity_lempelziv(rri, **kwargs))
+    out["CD"] = fractal_correlation(rri, delay=1, dimension=2, **kwargs)[0]
+    out["HFD"] = fractal_higuchi(rri, **kwargs)[0]
+    out["KFD"] = fractal_katz(rri)[0]
+    out["LZC"] = complexity_lempelziv(rri, **kwargs)[0]
 
     if show:
         _hrv_nonlinear_show(rri, out)
@@ -466,12 +466,12 @@ def _hrv_dfa(peaks, rri, out, n_windows="default", **kwargs):
     # Compute DFA alpha1
     short_window = np.linspace(dfa_windows[0][0], dfa_windows[0][1], n_windows_short).astype(int)
     # For monofractal
-    out["DFA_alpha1"] = fractal_dfa(rri, multifractal=False, windows=short_window, **kwargs)['slopes'][0]
+    out["DFA_alpha1"] = fractal_dfa(rri, multifractal=False, windows=short_window, **kwargs)[0]
     # For multifractal
     mdfa_alpha1 = fractal_dfa(rri,
                               multifractal=True,
                               q=np.arange(-5, 6),
-                              windows=short_window, **kwargs)
+                              windows=short_window, **kwargs)[1]
     out["DFA_alpha1_ExpRange"] = mdfa_alpha1['ExpRange']
     out["DFA_alpha1_ExpMean"] = mdfa_alpha1['ExpMean']
     out["DFA_alpha1_DimRange"] = mdfa_alpha1['DimRange']
@@ -491,12 +491,12 @@ def _hrv_dfa(peaks, rri, out, n_windows="default", **kwargs):
     else:
         long_window = np.linspace(dfa_windows[1][0], int(max_beats), n_windows_long).astype(int)
         # For monofractal
-        out["DFA_alpha2"] = fractal_dfa(rri, multifractal=False, windows=long_window, **kwargs)['slopes'][0]
+        out["DFA_alpha2"] = fractal_dfa(rri, multifractal=False, windows=long_window, **kwargs)[0]
         # For multifractal
         mdfa_alpha2 = fractal_dfa(rri,
                                   multifractal=True,
                                   q=np.arange(-5, 6),
-                                  windows=long_window, **kwargs)
+                                  windows=long_window, **kwargs)[1]
         out["DFA_alpha2_ExpRange"] = mdfa_alpha2['ExpRange']
         out["DFA_alpha2_ExpMean"] = mdfa_alpha2['ExpMean']
         out["DFA_alpha2_DimRange"] = mdfa_alpha2['DimRange']

--- a/neurokit2/rsp/rsp_rrv.py
+++ b/neurokit2/rsp/rsp_rrv.py
@@ -223,8 +223,8 @@ def _rsp_rrv_nonlinear(bbi):
     #    out["CSI_Modified"] = L ** 2 / T
 
     # Entropy
-    out["ApEn"] = entropy_approximate(bbi, dimension=2)
-    out["SampEn"] = entropy_sample(bbi, dimension=2, r=0.2 * np.std(bbi, ddof=1))
+    out.update(entropy_approximate(bbi, dimension=2))
+    out.update(entropy_sample(bbi, dimension=2, r=0.2 * np.std(bbi, ddof=1)))
 
     # DFA
     if len(bbi) / 10 > 16:

--- a/neurokit2/rsp/rsp_rrv.py
+++ b/neurokit2/rsp/rsp_rrv.py
@@ -223,29 +223,29 @@ def _rsp_rrv_nonlinear(bbi):
     #    out["CSI_Modified"] = L ** 2 / T
 
     # Entropy
-    out.update(entropy_approximate(bbi, dimension=2))
-    out.update(entropy_sample(bbi, dimension=2, r=0.2 * np.std(bbi, ddof=1)))
+    out["ApEn"] = entropy_approximate(bbi, dimension=2)[0]
+    out["SampEn"] = entropy_sample(bbi, dimension=2, r=0.2 * np.std(bbi, ddof=1))[0]
 
     # DFA
     if len(bbi) / 10 > 16:
-        out["DFA_alpha1"] = fractal_dfa(bbi, windows=np.arange(4, 17), multifractal=False)['slopes'][0]
+        out["DFA_alpha1"] = fractal_dfa(bbi, windows=np.arange(4, 17), multifractal=False)[0]
         # For multifractal
         mdfa_alpha1 = fractal_dfa(bbi,
                                   multifractal=True,
                                   q=np.arange(-5, 6),
-                                  windows=np.arange(4, 17))
+                                  windows=np.arange(4, 17))[1]
 
         out["DFA_alpha1_ExpRange"] = mdfa_alpha1['ExpRange']
         out["DFA_alpha1_ExpMean"] = mdfa_alpha1['ExpMean']
         out["DFA_alpha1_DimRange"] = mdfa_alpha1['DimRange']
         out["DFA_alpha1_DimMean"] = mdfa_alpha1['DimMean']
     if len(bbi) > 65:
-        out["DFA_alpha2"] = fractal_dfa(bbi, windows=np.arange(16, 65), multifractal=False)['slopes'][0]
+        out["DFA_alpha2"] = fractal_dfa(bbi, windows=np.arange(16, 65), multifractal=False)[0]
         # For multifractal
         mdfa_alpha2 = fractal_dfa(bbi,
                                   multifractal=True,
                                   q=np.arange(-5, 6),
-                                  windows=np.arange(16, 65))
+                                  windows=np.arange(16, 65))[1]
 
         out["DFA_alpha2_ExpRange"] = mdfa_alpha2['ExpRange']
         out["DFA_alpha2_ExpMean"] = mdfa_alpha2['ExpMean']

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ test_requirements = requirements + [
     "bioread",
     "mne",
     "pyentrp",
+    "antropy",
     "nolds",
     "biosppy==0.6.1",
     "cvxopt",

--- a/tests/tests_complexity.py
+++ b/tests/tests_complexity.py
@@ -22,7 +22,7 @@ def test_complexity_sanity():
     mdfa_q = [-5, -3, -1, 1, 3, 5]
 
     # Entropy
-    assert np.allclose(nk.entropy_fuzzy(signal), nk.entropy_sample(signal, fuzzy=True), atol=0.000001)
+    assert np.allclose(nk.entropy_fuzzy(signal)["FuzzyEn"], nk.entropy_sample(signal, fuzzy=True)["SampEn"], atol=0.000001)
 
     # Fractal
     fractal_dfa = nk.fractal_dfa(signal, windows=np.array([4, 8, 12, 20]))
@@ -36,8 +36,8 @@ def test_complexity_sanity():
     assert np.allclose(fractal_mdfa["ExpMean"], 2.350615727142904, atol=0.000001)
     assert np.allclose(fractal_mdfa["ExpRange"], 0.9937858280904406, atol=0.000001)
 
-    assert np.allclose(nk.fractal_correlation(signal), 0.7884473170763334, atol=0.000001)
-    assert np.allclose(nk.fractal_correlation(signal, r="nolds"), nolds.corr_dim(signal, 2), atol=0.0001)
+    assert np.allclose(nk.fractal_correlation(signal)["CD"], 0.7884473170763334, atol=0.000001)
+    assert np.allclose(nk.fractal_correlation(signal, r="nolds")["CD"], nolds.corr_dim(signal, 2), atol=0.0001)
 
 
 # =============================================================================
@@ -82,18 +82,18 @@ def test_complexity_vs_R():
     r = 0.2 * np.std(signal, ddof=1)
 
     # ApEn
-    apen = nk.entropy_approximate(signal, dimension=2, r=r)
+    apen = nk.entropy_approximate(signal, dimension=2, r=r)["ApEn"]
     assert np.allclose(apen, 0.04383386, atol=0.0001)
-    apen = nk.entropy_approximate(signal, dimension=3, delay=2, r=1)
+    apen = nk.entropy_approximate(signal, dimension=3, delay=2, r=1)["ApEn"]
     assert np.allclose(apen, 0.0004269369, atol=0.0001)
-    apen = nk.entropy_approximate(signal[0:200], dimension=2, delay=1, r=r)
+    apen = nk.entropy_approximate(signal[0:200], dimension=2, delay=1, r=r)["ApEn"]
     assert np.allclose(apen, 0.03632554, atol=0.0001)
 
     # SampEn
-    sampen = nk.entropy_sample(signal[0:300], dimension=2, r=r)
-    assert np.allclose(sampen, nk.entropy_sample(signal[0:300], dimension=2, r=r, distance="infinity"), atol=0.001)
+    sampen = nk.entropy_sample(signal[0:300], dimension=2, r=r)["SampEn"]
+    assert np.allclose(sampen, nk.entropy_sample(signal[0:300], dimension=2, r=r, distance="infinity")["SampEn"], atol=0.001)
     assert np.allclose(sampen, 0.03784376, atol=0.001)
-    sampen = nk.entropy_sample(signal[0:300], dimension=3, delay=2, r=r)
+    sampen = nk.entropy_sample(signal[0:300], dimension=3, delay=2, r=r)["SampEn"]
     assert np.allclose(sampen, 0.09185509, atol=0.01)
 
 
@@ -108,34 +108,34 @@ def test_complexity_vs_Python():
     signal = np.cos(np.linspace(start=0, stop=30, num=100))
 
     # Shannon
-    shannon = nk.entropy_shannon(signal)
+    shannon = nk.entropy_shannon(signal)["ShanEn"]
     #    assert scipy.stats.entropy(shannon, pd.Series(signal).value_counts())
     assert np.allclose(shannon - pyentrp.shannon_entropy(signal), 0)
 
     # Approximate
-    assert np.allclose(nk.entropy_approximate(signal), 0.17364897858477146)
+    assert np.allclose(nk.entropy_approximate(signal)["ApEn"], 0.17364897858477146)
     assert np.allclose(
-        nk.entropy_approximate(signal, dimension=2, r=0.2 * np.std(signal, ddof=1)) - entropy_app_entropy(signal, 2), 0
+        nk.entropy_approximate(signal, dimension=2, r=0.2 * np.std(signal, ddof=1))["ApEn"] - entropy_app_entropy(signal, 2), 0
     )
 
-    assert nk.entropy_approximate(signal, dimension=2, r=0.2 * np.std(signal, ddof=1)) != pyeeg_ap_entropy(
+    assert nk.entropy_approximate(signal, dimension=2, r=0.2 * np.std(signal, ddof=1))["ApEn"] != pyeeg_ap_entropy(
         signal, 2, 0.2 * np.std(signal, ddof=1)
     )
 
     # Sample
     assert np.allclose(
-        nk.entropy_sample(signal, dimension=2, r=0.2 * np.std(signal, ddof=1)) - entropy_sample_entropy(signal, 2), 0
+        nk.entropy_sample(signal, dimension=2, r=0.2 * np.std(signal, ddof=1))["SampEn"] - entropy_sample_entropy(signal, 2), 0
     )
-    assert np.allclose(nk.entropy_sample(signal, dimension=2, r=0.2) - nolds.sampen(signal, 2, 0.2), 0)
-    assert np.allclose(nk.entropy_sample(signal, dimension=2, r=0.2) - entro_py_sampen(signal, 2, 0.2, scale=False), 0)
-    assert np.allclose(nk.entropy_sample(signal, dimension=2, r=0.2) - pyeeg_samp_entropy(signal, 2, 0.2), 0)
+    assert np.allclose(nk.entropy_sample(signal, dimension=2, r=0.2)["SampEn"] - nolds.sampen(signal, 2, 0.2), 0)
+    assert np.allclose(nk.entropy_sample(signal, dimension=2, r=0.2)["SampEn"] - entro_py_sampen(signal, 2, 0.2, scale=False), 0)
+    assert np.allclose(nk.entropy_sample(signal, dimension=2, r=0.2)["SampEn"] - pyeeg_samp_entropy(signal, 2, 0.2), 0)
 
     #    import sampen
     #    sampen.sampen2(signal[0:300], mm=2, r=r)
 
-    assert nk.entropy_sample(signal, dimension=2, r=0.2) != pyentrp.sample_entropy(signal, 2, 0.2)[1]
+    assert nk.entropy_sample(signal, dimension=2, r=0.2)["SampEn"] != pyentrp.sample_entropy(signal, 2, 0.2)[1]
     assert (
-        nk.entropy_sample(signal, dimension=2, r=0.2 * np.sqrt(np.var(signal)))
+        nk.entropy_sample(signal, dimension=2, r=0.2 * np.sqrt(np.var(signal)))["SampEn"]
         != MultiscaleEntropy_sample_entropy(signal, 2, 0.2)[0.2][2]
     )
 
@@ -145,7 +145,7 @@ def test_complexity_vs_Python():
 
     # Fuzzy
     assert np.allclose(
-        nk.entropy_fuzzy(signal, dimension=2, r=0.2, delay=1) - entro_py_fuzzyen(signal, 2, 0.2, 1, scale=False), 0
+        nk.entropy_fuzzy(signal, dimension=2, r=0.2, delay=1)["FuzzyEn"] - entro_py_fuzzyen(signal, 2, 0.2, 1, scale=False), 0
     )
 
 #    # DFA

--- a/tests/tests_complexity.py
+++ b/tests/tests_complexity.py
@@ -24,22 +24,22 @@ def test_complexity_sanity():
     mdfa_q = [-5, -3, -1, 1, 3, 5]
 
     # Entropy
-    assert np.allclose(nk.entropy_fuzzy(signal)["FuzzyEn"], nk.entropy_sample(signal, fuzzy=True)["SampEn"], atol=0.000001)
+    assert np.allclose(nk.entropy_fuzzy(signal)[0], nk.entropy_sample(signal, fuzzy=True)[0], atol=0.000001)
 
     # Fractal
-    fractal_dfa = nk.fractal_dfa(signal, windows=np.array([4, 8, 12, 20]))
-    assert fractal_dfa['fluctuations'].shape == (4, 1)
-    assert np.allclose(fractal_dfa["slopes"][0], 2.10090484, atol=0.000001)
+    fractal_dfa, parameters = nk.fractal_dfa(signal, windows=np.array([4, 8, 12, 20]))
+    assert parameters['fluctuations'].shape == (4, 1)
+    assert np.allclose(fractal_dfa, 2.10090484, atol=0.000001)
 
-    fractal_mdfa = nk.fractal_dfa(signal, multifractal=True, q=mdfa_q)
-    assert fractal_mdfa['fluctuations'].shape == (70, len(mdfa_q))
-    assert np.allclose(fractal_mdfa["DimMean"], 0.6412650812085934, atol=0.000001)
-    assert np.allclose(fractal_mdfa["DimRange"], 1.1105927013188868, atol=0.000001)
-    assert np.allclose(fractal_mdfa["ExpMean"], 2.350615727142904, atol=0.000001)
-    assert np.allclose(fractal_mdfa["ExpRange"], 0.9937858280904406, atol=0.000001)
+    fractal_mdfa, parameters = nk.fractal_dfa(signal, multifractal=True, q=mdfa_q)
+    assert parameters['fluctuations'].shape == (70, len(mdfa_q))
+    assert np.allclose(parameters["DimMean"], 0.6412650812085934, atol=0.000001)
+    assert np.allclose(parameters["DimRange"], 1.1105927013188868, atol=0.000001)
+    assert np.allclose(parameters["ExpMean"], 2.350615727142904, atol=0.000001)
+    assert np.allclose(parameters["ExpRange"], 0.9937858280904406, atol=0.000001)
 
-    assert np.allclose(nk.fractal_correlation(signal)["CD"], 0.7884473170763334, atol=0.000001)
-    assert np.allclose(nk.fractal_correlation(signal, r="nolds")["CD"], nolds.corr_dim(signal, 2), atol=0.0001)
+    assert np.allclose(nk.fractal_correlation(signal)[0], 0.7884473170763334, atol=0.000001)
+    assert np.allclose(nk.fractal_correlation(signal, r="nolds")[0], nolds.corr_dim(signal, 2), atol=0.0001)
 
 
 # =============================================================================
@@ -158,7 +158,7 @@ def test_complexity_vs_Python():
             p_seq[index] = 0
         else:
             p_seq[index] = 1
-    p_seq = p_seq.astype(int)
+    p_seq = p_seq.astype(int).astype(str)
     p_seq = "".join(p_seq)
     
     assert np.allclose(


### PR DESCRIPTION
Return complexity indices in the form of tuples like so:

```
lzc, parameters = nk.complexity_lempelziv(signal, threshold="median")
```
where parameters is a dictionary. As part of https://github.com/neuropsychology/NeuroKit/projects/2#card-66890225

- [x] `fractal_higuchi` 
- [x] `fractal_katz` (empty parameters)
- [x] `fractal_dfa` 
- [x] `fractal_correlation`
- [x] `entropy_multiscale` - added a 'version' key in the dict to indicate if MSE/CMSE/RCMSE
- [x] `entropy_sample`
- [x] `entropy_fuzzy`
- [x] `entropy_approximate`
- [x] `entropy_shannon` (empty parameters)
- [x] `complexity_lempelziv`

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [ ] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [ ] My PR is targetted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)