### PR TITLE
[Fix] _interpolate_big method from signal_fixpeaks method

### DIFF
--- a/neurokit2/signal/signal_fixpeaks.py
+++ b/neurokit2/signal/signal_fixpeaks.py
@@ -530,7 +530,7 @@ def _interpolate_big(peaks, sampling_rate=1000, interval_max=None, relative_inte
         if relative_interval_max is not None:
             interval = signal_period(peaks, sampling_rate=sampling_rate, desired_length=None)
             interval = standardize(interval, robust=robust)
-            peaks, continue_loop = _interpolate_missing(peaks, interval, interval_max, sampling_rate)
+            peaks, continue_loop = _interpolate_missing(peaks, interval, relative_interval_max, sampling_rate)
 
     return peaks
 


### PR DESCRIPTION
# Description

This PR aims at repairing a possible bug in the  _interpolate_big method from the signal_fixpeaks method, i.e. wrong argument is passed to the interpolate function.

# Proposed Changes

One-line change which is self-explanatory.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [ x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [ x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [ x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ x] I have added the newly added features to **News.rst** (if applicable)