### PR TITLE
Distinguish intervals from peaks in `hrv_*()`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -20,6 +20,7 @@ Fixes
 +++++++++++++
 
 * Ensure detected offset in `emg_activation()` is not beyond signal length
+* Raise ValueError in `_hrv_sanitize_input()` if RRIs are detected instead of peaks
 
 
 0.1.4.1

--- a/neurokit2/hrv/hrv_utils.py
+++ b/neurokit2/hrv/hrv_utils.py
@@ -39,6 +39,19 @@ def _hrv_sanitize_input(peaks=None):
     else:
         peaks = _hrv_sanitize_peaks(peaks)
 
+    if isinstance(peaks, tuple):
+        if any(np.diff(peaks[0]) < 0):  # not continuously increasing
+            raise ValueError("NeuroKit error: _hrv_sanitize_input(): " +
+                             "The peak indices passed were detected as non-consecutive. You might have passed RR "  +
+                             "intervals instead of peaks. If so, convert RRIs into peaks using " +
+                             "nk.intervals_to_peaks().")
+    else:
+        if any(np.diff(peaks) < 0):
+            raise ValueError("NeuroKit error: _hrv_sanitize_input(): " +
+                             "The peak indices passed were detected as non-consecutive. You might have passed RR "  +
+                             "intervals instead of peaks. If so, convert RRIs into peaks using " +
+                             "nk.intervals_to_peaks().")
+
     return peaks
 
 

--- a/neurokit2/hrv/hrv_utils.py
+++ b/neurokit2/hrv/hrv_utils.py
@@ -39,18 +39,19 @@ def _hrv_sanitize_input(peaks=None):
     else:
         peaks = _hrv_sanitize_peaks(peaks)
 
-    if isinstance(peaks, tuple):
-        if any(np.diff(peaks[0]) < 0):  # not continuously increasing
-            raise ValueError("NeuroKit error: _hrv_sanitize_input(): " +
-                             "The peak indices passed were detected as non-consecutive. You might have passed RR "  +
-                             "intervals instead of peaks. If so, convert RRIs into peaks using " +
-                             "nk.intervals_to_peaks().")
-    else:
-        if any(np.diff(peaks) < 0):
-            raise ValueError("NeuroKit error: _hrv_sanitize_input(): " +
-                             "The peak indices passed were detected as non-consecutive. You might have passed RR "  +
-                             "intervals instead of peaks. If so, convert RRIs into peaks using " +
-                             "nk.intervals_to_peaks().")
+    if peaks is not None:
+        if isinstance(peaks, tuple):
+            if any(np.diff(peaks[0]) < 0):  # not continuously increasing
+                raise ValueError("NeuroKit error: _hrv_sanitize_input(): " +
+                                 "The peak indices passed were detected as non-consecutive. You might have passed RR "  +
+                                 "intervals instead of peaks. If so, convert RRIs into peaks using " +
+                                 "nk.intervals_to_peaks().")
+        else:
+            if any(np.diff(peaks) < 0):
+                raise ValueError("NeuroKit error: _hrv_sanitize_input(): " +
+                                 "The peak indices passed were detected as non-consecutive. You might have passed RR "  +
+                                 "intervals instead of peaks. If so, convert RRIs into peaks using " +
+                                 "nk.intervals_to_peaks().")
 
     return peaks
 


### PR DESCRIPTION
Throw error in `_hrv_sanitize_input()` if intervals instead of peaks detected