### PR TITLE
hrv_time() does not throw an ValueError for input array with constant…

### DIFF
--- a/neurokit2/hrv/hrv_time.py
+++ b/neurokit2/hrv/hrv_time.py
@@ -193,7 +193,10 @@ def _hrv_TINN(rri, bar_x, bar_y, binsize):
     min_error = 2 ** 14
     X = bar_x[np.argmax(bar_y)]  # bin where Y is max
     Y = np.max(bar_y)  # max value of Y
-    n = bar_x[np.where(bar_x - np.min(rri) > 0)[0][0]]  # starting search of N
+    idx_where = np.where(bar_x - np.min(rri) > 0)[0]
+    if len(idx_where) == 0:
+        return np.nan
+    n = bar_x[idx_where[0]]  # starting search of N
     m = X + binsize  # starting search value of M
     N = 0
     M = 0


### PR DESCRIPTION
# Description

This PR aims at fixing the issue that `nk.hrv_time()` raises an IndexError when an input array with constant RR intervals is passed.

# Proposed Changes

I changed the `_hrv_TINN()` function so that it checks whether the indices array is empty before attempting to access the array values. If the indices array is empty, the TINN feature cannot be computed and NaN is returned.


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.