### PR TITLE
[Fix] Signal_fixpeaks_neurokit

### DIFF
--- a/neurokit2/signal/signal_fixpeaks.py
+++ b/neurokit2/signal/signal_fixpeaks.py
@@ -142,7 +142,7 @@ def _signal_fixpeaks_neurokit(
     """Neurokit method."""
 
     peaks_clean = _remove_small(peaks, sampling_rate, interval_min, relative_interval_min, robust)
-    peaks_clean = _interpolate_big(peaks, sampling_rate, interval_max, relative_interval_max, robust)
+    peaks_clean = _interpolate_big(peaks_clean, sampling_rate, interval_max, relative_interval_max, robust)
 
     return peaks_clean
 


### PR DESCRIPTION
This PR aims at repairing a possible bug in the _signal_fixpeaks_neurokit method from the signal_fixpeaks method, i.e., the wrong argument is passed to the _interpolate_big function.

Another night - another catch! 

# Proposed Changes

One-line change which is self-explanatory.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [x] I have added the newly added features to **News.rst** (if applicable)