### PR TITLE
Functions to account for more `mne` features

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -16,6 +16,11 @@ New Features
 
 * Updates logic to find `kmax` in `fractal_higuchi()`
 * Add RSP_Amplitude_Baseline in event-related analysis
+* Add argument `add_firstsamples` in `mne_channel_extract()` to account for first sample attribute in mne raw objects
+* Allow plotting of `mne.Epochs` in `epochs_plot()`
+* Add `mne_crop()` to crop `mne` Raw objects with additional flexibility to specify first and last elements
+* Plotting function in `eeg_badchannels()` to visualize overlay of individual EEG channels and highlighting of bad ones
+* Add `eog_peaks()` as wrapper for `eog_findpeaks()`
 
 Fixes
 +++++++++++++

--- a/neurokit2/eeg/__init__.py
+++ b/neurokit2/eeg/__init__.py
@@ -1,21 +1,24 @@
 """Submodule for NeuroKit."""
 
-from .mne_data import mne_data
+from .eeg_badchannels import eeg_badchannels
+from .eeg_diss import eeg_diss
+from .eeg_gfp import eeg_gfp
+from .eeg_rereference import eeg_rereference
 from .mne_channel_add import mne_channel_add
 from .mne_channel_extract import mne_channel_extract
+from .mne_crop import mne_crop
+from .mne_data import mne_data
 from .mne_to_df import mne_to_df, mne_to_dict
-from .eeg_rereference import eeg_rereference
-from .eeg_gfp import eeg_gfp
-from .eeg_diss import eeg_diss
-from .eeg_badchannels import eeg_badchannels
 
-
-__all__ = ["mne_data",
-           "mne_channel_add",
-           "mne_channel_extract",
-           "mne_to_df",
-           "mne_to_dict",
-           "eeg_rereference",
-           "eeg_gfp",
-           "eeg_diss",
-           "eeg_badchannels"]
+__all__ = [
+    "mne_data",
+    "mne_channel_add",
+    "mne_channel_extract",
+    "mne_crop",
+    "mne_to_df",
+    "mne_to_dict",
+    "eeg_rereference",
+    "eeg_gfp",
+    "eeg_diss",
+    "eeg_badchannels",
+]

--- a/neurokit2/eeg/eeg_badchannels.py
+++ b/neurokit2/eeg/eeg_badchannels.py
@@ -3,8 +3,8 @@ import numpy as np
 import pandas as pd
 import scipy.stats
 
-from ..stats import standardize, mad, hdi
 from ..signal import signal_zerocrossings
+from ..stats import hdi, mad, standardize
 
 
 def eeg_badchannels(eeg, bad_threshold=0.5, distance_threshold=0.99):
@@ -19,7 +19,7 @@ def eeg_badchannels(eeg, bad_threshold=0.5, distance_threshold=0.99):
         on which an observation is considered an outlier to be considered as bad. The default, 0.5,
         means that a channel must score as an outlier on half or more of the indices.
     distance_threshold : float
-        The quantile that desfines the absolute distance from the mean, i.e., the z-score for a
+        The quantile that defines the absolute distance from the mean, i.e., the z-score for a
         value of a variable to be considered an outlier. For instance, .975 becomes
         ``scipy.stats.norm.ppf(.975) ~= 1.96``. The default value (.99) means that all observations
         beyond 2.33 SD from the mean will be classified as outliers.
@@ -59,23 +59,27 @@ def eeg_badchannels(eeg, bad_threshold=0.5, distance_threshold=0.99):
         channel = eeg[i, :]
 
         hdi_values = hdi(channel, ci=0.90)
-        info = {"Channel": [i],
-                "SD": [np.nanstd(channel, ddof=1)],
-                "Mean": [np.nanmean(channel)],
-                "MAD": [mad(channel)],
-                "Median": [np.nanmedian(channel)],
-                "Skewness": [scipy.stats.skew(channel)],
-                "Kurtosis": [scipy.stats.kurtosis(channel)],
-                "Amplitude": [np.max(channel) - np.min(channel)],
-                "CI_low": [hdi_values[0]],
-                "CI_high": [hdi_values[1]],
-                "n_ZeroCrossings": [len(signal_zerocrossings(channel - np.nanmean(channel)))]}
+        info = {
+            "Channel": [i],
+            "SD": [np.nanstd(channel, ddof=1)],
+            "Mean": [np.nanmean(channel)],
+            "MAD": [mad(channel)],
+            "Median": [np.nanmedian(channel)],
+            "Skewness": [scipy.stats.skew(channel)],
+            "Kurtosis": [scipy.stats.kurtosis(channel)],
+            "Amplitude": [np.max(channel) - np.min(channel)],
+            "CI_low": [hdi_values[0]],
+            "CI_high": [hdi_values[1]],
+            "n_ZeroCrossings": [len(signal_zerocrossings(channel - np.nanmean(channel)))],
+        }
         results.append(pd.DataFrame(info))
     results = pd.concat(results, axis=0)
     results = results.set_index("Channel")
 
     z = standardize(results)
-    results["Bad"] = (z.abs() > scipy.stats.norm.ppf(distance_threshold)).sum(axis=1) / len(results.columns)
+    results["Bad"] = (z.abs() > scipy.stats.norm.ppf(distance_threshold)).sum(axis=1) / len(
+        results.columns
+    )
     bads = ch_names[np.where(results["Bad"] >= bad_threshold)[0]]
 
     return list(bads), results

--- a/neurokit2/eeg/eeg_badchannels.py
+++ b/neurokit2/eeg/eeg_badchannels.py
@@ -40,7 +40,7 @@ def eeg_badchannels(eeg, bad_threshold=0.5, distance_threshold=0.99, show=False)
     >>> import neurokit2 as nk
     >>>
     >>> eeg = nk.mne_data("filt-0-40_raw")
-    >>> bads, info = nk.eeg_badchannels(eeg, show=True)
+    >>> bads, info = nk.eeg_badchannels(eeg, distance_threshold=0.95, show=False)
 
     """
     if isinstance(eeg, (pd.DataFrame, np.ndarray)) is False:
@@ -110,17 +110,15 @@ def _plot_eeg_badchannels(eeg, bads, ch_names):
 
     # Plot good channels
     for i in range(len(eeg)):
-        channel = eeg[i, :]
-
         if i not in bads_list:
+            channel = eeg[i, :]
             ax.plot(np.arange(1, len(channel)+1), channel, c=colors_good[i])
 
     # Plot bad channels
-    for i in bads_list:
-        channel = eeg[i, :]
-        for color in colors_bad:
-            ax.plot(np.arange(1, len(channel)+1), channel, c=color, label=ch_names[i])
+    for i, bad in enumerate(bads_list):
+        channel = eeg[bad, :]
+        ax.plot(np.arange(1, len(channel)+1), channel, c=colors_bad[i], label=ch_names[i])
 
     ax.legend(loc="upper right")
-    
+
     return fig

--- a/neurokit2/eeg/mne_channel_add.py
+++ b/neurokit2/eeg/mne_channel_add.py
@@ -98,7 +98,7 @@ def mne_channel_add(
 
     # Add channel
     raw = raw.copy()
-    raw.add_channels([channel], force_update_info=True) # In-place
+    raw.add_channels([channel], force_update_info=True)  # In-place
 
     # Restore old verbosity level
     mne.set_log_level(old_verbosity_level)

--- a/neurokit2/eeg/mne_channel_extract.py
+++ b/neurokit2/eeg/mne_channel_extract.py
@@ -22,7 +22,8 @@ def mne_channel_extract(raw, what, name=None, add_firstsamples=False):
         Otherwise, defaults to None.
     add_firstsamples : bool
         Defaults to `False`. Mne's objects store the value of a delay between
-        the start of the system and the start of the recording (see https://mne.tools/stable/generated/mne.io.Raw.html#mne.io.Raw.first_samp).
+        the start of the system and the start of the recording
+        (see https://mne.tools/stable/generated/mne.io.Raw.html#mne.io.Raw.first_samp).
         Taking this into account can be useful when extracting channels from the Raw object to detect events indices
         that are passed back to MNE again. When `add_firstsamples` is set to `True`, the offset will be explicitly
         added at the beginning of the signal and filled with NaNs. If `add_firstsamples` is a float or an integer,

--- a/neurokit2/eeg/mne_channel_extract.py
+++ b/neurokit2/eeg/mne_channel_extract.py
@@ -26,7 +26,8 @@ def mne_channel_extract(raw, what, name=None, add_firstsamples=False):
         Taking this into account can be useful when extracting channels from the Raw object to detect events indices
         that are passed back to MNE again. When `add_firstsamples` is set to `True`, the offset will be explicitly
         added at the beginning of the signal and filled with NaNs. If `add_firstsamples` is a float or an integer,
-        the offset will filled with these values instead.
+        the offset will filled with these values instead. If it is set to `"backfill"`, will prepend with the first
+        real value.
 
     Returns
     ----------
@@ -75,8 +76,12 @@ def mne_channel_extract(raw, what, name=None, add_firstsamples=False):
             channels = channels.rename(name)
 
     # Add first_samp
-    if isinstance(add_firstsamples, bool) and add_firstsamples is True:  # fill with na
+    if isinstance(add_firstsamples, bool) and add_firstsamples is True:  # Fill with na
         add_firstsamples = np.nan
+    if isinstance(add_firstsamples, str):  # Back fill
+        add_firstsamples = channels.iloc[0]
+        if isinstance(channels, pd.DataFrame):
+            add_firstsamples = dict(add_firstsamples)
 
     if add_firstsamples is not False:
         if isinstance(channels, pd.Series):

--- a/neurokit2/eeg/mne_crop.py
+++ b/neurokit2/eeg/mne_crop.py
@@ -4,7 +4,8 @@ import numpy as np
 def mne_crop(raw, tmin=0.0, tmax=None, include_tmax=True, smin=None, smax=None):
     """Crop mne.Raw objects.
     Similar to `raw.crop()` but with a few critical differences:
-    - It recreates a whole new Raw object, and as such drops all information pertaining to the original data (https://github.com/mne-tools/mne-python/issues/9759).
+    - It recreates a whole new Raw object, and as such drops all information pertaining to the original data
+    (https://github.com/mne-tools/mne-python/issues/9759).
     - There is the possibility of specifying directly the first and last samples.
     """
     # Try loading mne

--- a/neurokit2/eeg/mne_crop.py
+++ b/neurokit2/eeg/mne_crop.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+
+def mne_crop(raw, tmin=0.0, tmax=None, include_tmax=True, smin=None, smax=None):
+    """Crop mne.Raw objects.
+    Similar to `raw.crop()` but with a few critical differences:
+    - It recreates a whole new Raw object, and as such drops all information pertaining to the original data (https://github.com/mne-tools/mne-python/issues/9759).
+    - There is the possibility of specifying directly the first and last samples.
+    """
+    # Try loading mne
+    try:
+        import mne
+    except ImportError:
+        raise ImportError(
+            "NeuroKit error: eeg_channel_add(): the 'mne' module is required for this function to run. ",
+            "Please install it first (`pip install mne`).",
+        )
+
+    # Convert time to samples
+    if smin is None or smax is None:
+        max_time = (raw.n_times - 1) / raw.info["sfreq"]
+        if tmax is None:
+            tmax = max_time
+
+        if tmin > tmax:
+            raise ValueError("tmin (%s) must be less than tmax (%s)" % (tmin, tmax))
+        if tmin < 0.0:
+            raise ValueError("tmin (%s) must be >= 0" % (tmin,))
+        elif tmax > max_time:
+            raise ValueError(
+                "tmax (%s) must be less than or equal to the max "
+                "time (%0.4f sec)" % (tmax, max_time)
+            )
+
+        # Convert time to first and last samples
+        new_smin, new_smax = np.where(
+            _time_mask(raw.times, tmin, tmax, sfreq=raw.info["sfreq"], include_tmax=include_tmax)
+        )[0][[0, -1]]
+
+    if smin is None:
+        smin = new_smin
+    if smax is None:
+        smax = new_smax
+    if include_tmax:
+        smax += 1
+
+    # Re-create the Raw object (note that mne does smin : smin + 1)
+    raw = mne.io.RawArray(
+        raw._data[:, int(smin) : int(smax)].copy(), raw.info, verbose="WARNING"
+    )
+
+    return raw
+
+
+def _time_mask(times, tmin=None, tmax=None, sfreq=None, raise_error=True, include_tmax=True):
+    """Copied from https://github.com/mne-tools/mne-python/mne/utils/numerics.py#L466."""
+    orig_tmin = tmin
+    orig_tmax = tmax
+    tmin = -np.inf if tmin is None else tmin
+    tmax = np.inf if tmax is None else tmax
+    if not np.isfinite(tmin):
+        tmin = times[0]
+    if not np.isfinite(tmax):
+        tmax = times[-1]
+        include_tmax = True  # ignore this param when tmax is infinite
+    if sfreq is not None:
+        # Push to a bit past the nearest sample boundary first
+        sfreq = float(sfreq)
+        tmin = int(round(tmin * sfreq)) / sfreq - 0.5 / sfreq
+        tmax = int(round(tmax * sfreq)) / sfreq
+        tmax += (0.5 if include_tmax else -0.5) / sfreq
+    else:
+        assert include_tmax  # can only be used when sfreq is known
+    if raise_error and tmin > tmax:
+        raise ValueError(
+            "tmin (%s) must be less than or equal to tmax (%s)" % (orig_tmin, orig_tmax)
+        )
+    mask = times >= tmin
+    mask &= times <= tmax
+    if raise_error and not mask.any():
+        extra = "" if include_tmax else "when include_tmax=False "
+        raise ValueError(
+            "No samples remain when using tmin=%s and tmax=%s %s"
+            "(original time bounds are [%s, %s])"
+            % (orig_tmin, orig_tmax, extra, times[0], times[-1])
+        )
+    return mask

--- a/neurokit2/eeg/mne_to_df.py
+++ b/neurokit2/eeg/mne_to_df.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-import pandas as pd
 import numpy as np
+import pandas as pd
+
 
 def mne_to_df(eeg):
     """Convert mne Raw or Epochs object to dataframe or dict of dataframes.
@@ -23,11 +24,6 @@ def mne_to_df(eeg):
     >>> eeg = nk.mne_data("filt-0-40_raw")
     >>> eeg = nk.eeg_rereference(eeg, 'average')
     >>>
-    >>> gfp = nk.eeg_gfp(eeg)
-    >>> gfp_z = nk.eeg_gfp(eeg, normalize=True)
-    >>> gfp_zr = nk.eeg_gfp(eeg, normalize=True, robust=True)
-    >>> gfp_s = nk.eeg_gfp(eeg, smooth=0.05)
-    >>> nk.signal_plot([gfp[0:500], gfp_z[0:500], gfp_zr[0:500], gfp_s[0:500]], standardize=True)
 
     """
     # Try loading mne
@@ -44,12 +40,12 @@ def mne_to_df(eeg):
         data = _mne_to_df_epochs(eeg)
 
     # If raw object
-    elif isinstance(eeg, mne.io.Raw):
+    elif isinstance(eeg, (mne.io.Raw, mne.io.RawArray)):
         data = _mne_to_df_raw(eeg)
 
     # If array or dataframe, skip and return
     elif isinstance(eeg, (pd.DataFrame, np.ndarray)):
-        return data
+        return eeg
 
     # it might be an evoked object
     else:

--- a/neurokit2/eog/__init__.py
+++ b/neurokit2/eog/__init__.py
@@ -7,15 +7,16 @@ from .eog_eventrelated import eog_eventrelated
 from .eog_features import eog_features
 from .eog_findpeaks import eog_findpeaks
 from .eog_intervalrelated import eog_intervalrelated
+from .eog_peaks import eog_peaks
 from .eog_plot import eog_plot
 from .eog_process import eog_process
-
 
 __all__ = [
     "eog_rate",
     "eog_clean",
     "eog_features",
     "eog_findpeaks",
+    "eog_peaks",
     "eog_process",
     "eog_plot",
     "eog_eventrelated",

--- a/neurokit2/eog/eog_findpeaks.py
+++ b/neurokit2/eog/eog_findpeaks.py
@@ -13,7 +13,8 @@ from .eog_simulate import _eog_simulate_blink
 def eog_findpeaks(veog_cleaned, sampling_rate=None, method="mne", **kwargs):
     """Locate EOG eye blinks.
 
-    Locate EOG eye blinks.
+    Low-level function used by `eog_peaks()` to identify blinks in an EOG signal using a different
+    set of algorithms. See `eog_peaks()` for details.
 
     Parameters
     ----------
@@ -39,7 +40,7 @@ def eog_findpeaks(veog_cleaned, sampling_rate=None, method="mne", **kwargs):
 
     See Also
     --------
-    eog_clean
+    eog_peaks
 
     Examples
     --------
@@ -78,15 +79,6 @@ def eog_findpeaks(veog_cleaned, sampling_rate=None, method="mne", **kwargs):
     >>> # fig5 = nk.events_plot(jammes2008, eog_cleaned)
     >>> # fig5
 
-
-    References
-    ----------
-    - Agarwal, M., & Sivakumar, R. (2019). Blink: A Fully Automated Unsupervised Algorithm for
-    Eye-Blink Detection in EEG Signals. In 2019 57th Annual Allerton Conference on Communication,
-    Control, and Computing (Allerton) (pp. 1113-1121). IEEE.
-    - Kleifges, K., Bigdely-Shamlo, N., Kerick, S. E., & Robbins, K. A. (2017). BLINKER: automated
-    extraction of ocular indices from EEG enabling large-scale analysis. Frontiers in neuroscience, 11, 12.
-
     """
     # Sanitize input
     eog_cleaned = as_vector(veog_cleaned)
@@ -104,7 +96,10 @@ def eog_findpeaks(veog_cleaned, sampling_rate=None, method="mne", **kwargs):
     #    elif method in ["jammes2008", "jammes"]:
     #        peaks = _eog_findpeaks_jammes2008(eog_cleaned, sampling_rate=sampling_rate)
     else:
-        raise ValueError("NeuroKit error: eog_peaks(): 'method' should be " "one of 'mne', 'brainstorm' or 'blinker'.")
+        raise ValueError(
+            "NeuroKit error: eog_peaks(): 'method' should be "
+            "one of 'mne', 'brainstorm' or 'blinker'."
+        )
 
     return peaks
 
@@ -115,17 +110,23 @@ def eog_findpeaks(veog_cleaned, sampling_rate=None, method="mne", **kwargs):
 def _eog_findpeaks_neurokit(eog_cleaned, sampling_rate=1000, threshold=0.33, show=True):
     """In-house EOG blink detection."""
     peaks = signal_findpeaks(eog_cleaned, relative_height_min=1.25)["Peaks"]
-    peaks = signal_fixpeaks(peaks=peaks, sampling_rate=sampling_rate, interval_min=0.2, method="neurokit")
+    peaks = signal_fixpeaks(
+        peaks=peaks, sampling_rate=sampling_rate, interval_min=0.2, method="neurokit"
+    )
     peaks = _eog_findpeaks_neurokit_filterblinks(
         eog_cleaned, peaks, sampling_rate=sampling_rate, threshold=threshold, show=show
     )
     return peaks
 
 
-def _eog_findpeaks_neurokit_filterblinks(eog_cleaned, peaks, sampling_rate=1000, threshold=0.5, show=False):
+def _eog_findpeaks_neurokit_filterblinks(
+    eog_cleaned, peaks, sampling_rate=1000, threshold=0.5, show=False
+):
     """Compare each detected event to blink template and reject it if too different."""
     # Get epoch around each blink
-    events = epochs_create(eog_cleaned, peaks, sampling_rate=sampling_rate, epochs_start=-0.4, epochs_end=0.6)
+    events = epochs_create(
+        eog_cleaned, peaks, sampling_rate=sampling_rate, epochs_start=-0.4, epochs_end=0.6
+    )
     events = epochs_to_array(events)  # Convert to 2D array
 
     # Generate Blink-template
@@ -260,7 +261,9 @@ def _eog_findpeaks_blinker(eog_cleaned, sampling_rate=1000):
 
     candidates = np.array(potential_blinks)[np.append(0, indexes)[blinks]]
 
-    _, peaks, _, _, _, _ = _eog_features_delineate(eog_cleaned, candidates, sampling_rate=sampling_rate)
+    _, peaks, _, _, _, _ = _eog_features_delineate(
+        eog_cleaned, candidates, sampling_rate=sampling_rate
+    )
 
     # Blink peak markers
     peaks = np.array(peaks)

--- a/neurokit2/eog/eog_peaks.py
+++ b/neurokit2/eog/eog_peaks.py
@@ -1,0 +1,86 @@
+from ..signal import signal_formatpeaks
+from .eog_findpeaks import eog_findpeaks
+
+
+def eog_peaks(veog_cleaned, sampling_rate=None, method="mne", **kwargs):
+    """Locate EOG eye blinks.
+
+    Locate EOG eye blinks.
+
+    Parameters
+    ----------
+    veog_cleaned : Union[list, np.array, pd.Series]
+        The cleaned vertical EOG channel. Note that it must be positively oriented, i.e., blinks must
+        appear as upward peaks.
+    sampling_rate : int
+        The signal sampling rate (in Hz, i.e., samples/second). Needed for method 'blinker' or
+        'jammes2008'.
+    method : str
+        The peak detection algorithm. Can be one of 'neurokit', 'mne' (requires the MNE package
+        to be installed), or 'brainstorm' or 'blinker'.
+    sampling_rate : int
+        The sampling frequency of the EOG signal (in Hz, i.e., samples/second). Needs to be supplied if the
+        method to be used is 'blinker', otherwise defaults to None.
+    **kwargs
+        Other arguments passed to functions.
+
+    Returns
+    -------
+    array
+        Vector containing the samples at which EOG-peaks occur,
+
+    See Also
+    --------
+    eog_clean
+
+    Examples
+    --------
+    >>> import neurokit2 as nk
+    >>>
+    >>> # Get data
+    >>> eog_signal = nk.data('eog_100hz')
+    >>> eog_cleaned = nk.eog_clean(eog_signal, sampling_rate=100)
+    >>>
+    >>> # NeuroKit method
+    >>> signals, info_nk = nk.eog_peaks(eog_cleaned,
+    ...                                 sampling_rate=100,
+    ...                                 method="neurokit",
+    ...                                 threshold=0.33,
+    ...                                 show=True)
+    >>> fig1 = nk.events_plot(info_nk["EOG_Blinks"], eog_cleaned)
+    >>> fig1  # doctest: +SKIP
+    >>>
+    >>> # MNE-method
+    >>> signals, info_mne = nk.eog_peaks(eog_cleaned, method="mne")
+    >>> fig2 = nk.events_plot(info_mne["EOG_Blinks"], eog_cleaned)
+    >>> fig2  # doctest: +SKIP
+    >>>
+    >>> # brainstorm method
+    >>> signals, info_brainstorm = nk.eog_peaks(eog_cleaned, method="brainstorm")
+    >>> fig3 = nk.events_plot(info_brainstorm["EOG_Blinks"], eog_cleaned)
+    >>> fig3  # doctest: +SKIP
+    >>>
+    >>> # blinker method
+    >>> signals, info_blinker = nk.eog_peaks(eog_cleaned, sampling_rate=100, method="blinker")
+    >>> fig4 = nk.events_plot(info_blinker["EOG_Blinks"], eog_cleaned)
+    >>> fig4  # doctest: +SKIP
+    >>>
+
+
+    References
+    ----------
+    - Agarwal, M., & Sivakumar, R. (2019). Blink: A Fully Automated Unsupervised Algorithm for
+    Eye-Blink Detection in EEG Signals. In 2019 57th Annual Allerton Conference on Communication,
+    Control, and Computing (Allerton) (pp. 1113-1121). IEEE.
+    - Kleifges, K., Bigdely-Shamlo, N., Kerick, S. E., & Robbins, K. A. (2017). BLINKER: automated
+    extraction of ocular indices from EEG enabling large-scale analysis. Frontiers in neuroscience, 11, 12.
+
+    """
+    peaks = eog_findpeaks(veog_cleaned, sampling_rate=sampling_rate, method=method, **kwargs)
+    info = {"EOG_Blinks": peaks}
+
+    instant_peaks = signal_formatpeaks(info, desired_length=len(veog_cleaned), peak_indices=peaks)
+    signals = instant_peaks
+    info["sampling_rate"] = sampling_rate  # Add sampling rate in dict info
+
+    return signals, info


### PR DESCRIPTION
- [x] Account for `first_samp` attribute in mne channels
`mne` raw objects have an attribute called `first_samp` corresponding to the time lapsed after the system start and before the start of the recording, and so the first event's sample number is always > 0. This is taken into account for in mne functions but not in neurokit yet 

See http://predictablynoisy.com/mne-python/generated/mne.io.RawArray.html

- [x] `epochs_plot()` to work with mne objects