### PR TITLE
Fix matrix B created too short

### DIFF
--- a/neurokit2/signal/signal_detrend.py
+++ b/neurokit2/signal/signal_detrend.py
@@ -134,7 +134,7 @@ def _signal_detrend_tarvainen2002(signal, regularization=500):
     """
     N = len(signal)
     identity = np.eye(N)
-    B = np.dot(np.ones((N - 2, 1)), np.array([[1, -2, 1]]))
+    B = np.dot(np.ones((N, 1)), np.array([[1, -2, 1]]))
     D_2 = scipy.sparse.dia_matrix((B.T, [0, 1, 2]), shape=(N - 2, N))  # pylint: disable=E1101
     inv = np.linalg.inv(identity + regularization ** 2 * D_2.T @ D_2)
     z_stat = ((identity - inv)) @ signal


### PR DESCRIPTION
# Description

This PR aims at adding this fix where the data matrix B for creating the sparse matrix D_2 was created too short (N-2) and it didn't reach the two last columns in the sparse matrix upon creation.

# Proposed Changes

I changed the `_signal_detrend_tarvainen2002(signal, regularization=500)` function so that I extended the matrix B to fix the mentioned issue.


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)