### PR TITLE
Remove unused args in hrv_time

### DIFF
--- a/neurokit2/hrv/hrv_time.py
+++ b/neurokit2/hrv/hrv_time.py
@@ -103,8 +103,8 @@ def hrv_time(peaks, sampling_rate=1000, show=False, **kwargs):
     out["MeanNN"] = np.nanmean(rri)
     out["SDNN"] = np.nanstd(rri, ddof=1)
     for i in [1, 2, 5]:
-        out["SDANN" + str(i)] = _sdann(rri, sampling_rate, window=i)
-        out["SDNNI" + str(i)] = _sdnni(rri, sampling_rate, window=i)
+        out["SDANN" + str(i)] = _sdann(rri, window=i)
+        out["SDNNI" + str(i)] = _sdnni(rri, window=i)
 
     # Difference-based
     out["RMSSD"] = np.sqrt(np.nanmean(diff_rri ** 2))
@@ -159,7 +159,7 @@ def _hrv_time_show(rri, **kwargs):
     return fig
 
 
-def _sdann(rri, sampling_rate, window=1):
+def _sdann(rri, window=1):
 
     window_size = window * 60 * 1000  # Convert window in min to ms
     n_windows = int(np.round(np.cumsum(rri)[-1] / window_size))
@@ -176,7 +176,7 @@ def _sdann(rri, sampling_rate, window=1):
     return sdann
 
 
-def _sdnni(rri, sampling_rate, window=1):
+def _sdnni(rri, window=1):
 
     window_size = window * 60 * 1000  # Convert window in min to ms
     n_windows = int(np.round(np.cumsum(rri)[-1] / window_size))


### PR DESCRIPTION
Remove unused args in `_sdnni()` and `_sdann()`

As mentioned [here](https://github.com/neuropsychology/NeuroKit/pull/571#issuecomment-961596438), `sampling_rate` is not used in either functions. 

@DominiqueMakowski the multiplication by 1000 is to convert from seconds to milliseconds. Since window_size is in minute, there is no need to use `sampling_rate` in the conversion.


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)