### PR TITLE
Error removed in the Readme EMG example part

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -307,7 +307,7 @@ Electromyography (EMG)
     signal, info = nk.emg_process(emg, sampling_rate=250)
 
     # Visualise the processing
-    nk.emg_plot(signals, sampling_rate=250)
+    nk.emg_plot(signal, sampling_rate=250)
 
 
 .. image:: https://raw.github.com/neuropsychology/NeuroKit/master/docs/readme/README_emg.png


### PR DESCRIPTION




# Description

If we run the current example code for EMG in the Readme text, this will result in the below error.
![image](https://user-images.githubusercontent.com/73081215/147229949-b540ce66-2b1c-4fd1-b744-d13475e639e1.png)

# Proposed Changes

I removed the ending s from the signals, now it works fine!


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)
Hope I can do more contributions in the next stages😊

- [ ] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [ ] My PR is targetted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)