### PR TITLE
Error removed in the Readme EMG example part

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -304,7 +304,7 @@ Electromyography (EMG)
     emg = nk.emg_simulate(duration=10, sampling_rate=250, burst_number=3)
 
     # Process it
-    signal, info = nk.emg_process(emg, sampling_rate=250)
+    signals, info = nk.emg_process(emg, sampling_rate=250)
 
     # Visualise the processing
     nk.emg_plot(signals, sampling_rate=250)


### PR DESCRIPTION


# Description

If we run the current example code for EMG in the Readme text, this will result in the below error.
![147229949-b540ce66-2b1c-4fd1-b744-d13475e639e1](https://user-images.githubusercontent.com/73081215/147383220-790d24ef-e93f-4a45-a45e-65a2c70efc2f.png)

# Proposed Changes

I added an ending "s" to the signal, now it works fine!


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [ ] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [ ] My PR is targetted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)