### PR TITLE
Fix complexity_tolerance using recurrence method

### DIFF
--- a/neurokit2/complexity/optim_complexity_tolerance.py
+++ b/neurokit2/complexity/optim_complexity_tolerance.py
@@ -60,7 +60,7 @@ def complexity_tolerance(
     >>>
     >>> r, info = nk.complexity_tolerance(signal, delay=1, dimension=10, method = 'recurrence', show=True)
     >>> r
-    0.06298107683978625
+    0.1259621536795725
     >>>
     >>> # Slow
     >>> r, info = nk.complexity_tolerance(signal, delay=8, dimension=6, method = 'maxApEn', show=True)

--- a/neurokit2/complexity/optim_complexity_tolerance.py
+++ b/neurokit2/complexity/optim_complexity_tolerance.py
@@ -127,7 +127,7 @@ def _optimize_tolerance_recurrence(signal, r_range=None, delay=None, dimension=N
     for i, r in enumerate(r_range):
         recurrence_rate[i] = (d[idx] <= r).sum() / n
     # Closest to 0.05 (5%)
-    optimal = r_range[np.abs(r_range - 0.05).argmin()]
+    optimal = r_range[np.abs(recurrence_rate - 0.05).argmin()]
 
     return optimal, {"Values": r_range, "Scores": recurrence_rate}
 


### PR DESCRIPTION
# Description

This PR aims to fix the selection of the optimal r value on `_optimize_tolerance_recurrence`.

# Proposed Changes

On line 130, the `r_range` value closest to 0.05 was being used to select itself, when in fact it's the `recurrence_rate` value closest to 0.05 to be used to select the `r_range` value.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [X] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [X] My PR is targetted at the **dev branch** (and not towards the master branch).
- [X] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)