### PR TITLE
[Fix] hrv_frequency(): changes in frequency bands correctly propagate

### DIFF
--- a/neurokit2/hrv/hrv_frequency.py
+++ b/neurokit2/hrv/hrv_frequency.py
@@ -124,13 +124,15 @@ def hrv_frequency(
     if isinstance(peaks, tuple):  # Detect actual sampling rate
         peaks, sampling_rate = peaks[0], peaks[1]
 
-    # infer maximum frequency here
-    max_frequency = vhf[1]
-
     # Compute R-R intervals (also referred to as NN) in milliseconds (interpolated at 1000 Hz by default)
-    rri, sampling_rate = _hrv_get_rri(peaks, sampling_rate=sampling_rate, interpolate=True, **kwargs)
+    rri, sampling_rate = _hrv_get_rri(
+        peaks, sampling_rate=sampling_rate, interpolate=True, **kwargs
+    )
 
     frequency_band = [ulf, vlf, lf, hf, vhf]
+
+    # Find maximum frequency
+    max_frequency = np.max([np.max(i) for i in frequency_band])
 
     power = signal_power(
         rri,

--- a/neurokit2/hrv/hrv_frequency.py
+++ b/neurokit2/hrv/hrv_frequency.py
@@ -118,23 +118,26 @@ def hrv_frequency(
     Rate Variability. Simul. Notes Eur., 27(4), 183-190.
 
     """
+
     # Sanitize input
     peaks = _hrv_sanitize_input(peaks)
     if isinstance(peaks, tuple):  # Detect actual sampling rate
         peaks, sampling_rate = peaks[0], peaks[1]
 
+    # infer maximum frequency here
+    max_frequency = vhf[1]
+
     # Compute R-R intervals (also referred to as NN) in milliseconds (interpolated at 1000 Hz by default)
-    rri, sampling_rate = _hrv_get_rri(
-        peaks, sampling_rate=sampling_rate, interpolate=True, **kwargs
-    )
+    rri, sampling_rate = _hrv_get_rri(peaks, sampling_rate=sampling_rate, interpolate=True, **kwargs)
 
     frequency_band = [ulf, vlf, lf, hf, vhf]
+
     power = signal_power(
         rri,
         frequency_band=frequency_band,
         sampling_rate=sampling_rate,
         method=psd_method,
-        max_frequency=0.5,
+        max_frequency=max_frequency,
         show=False,
         normalize=normalize,
         order_criteria=order_criteria,
@@ -172,10 +175,16 @@ def hrv_frequency(
         _hrv_frequency_show(
             rri,
             out_bands,
+            ulf=ulf,
+            vlf=vlf,
+            lf=lf,
+            hf=hf,
+            vhf=vhf,
             sampling_rate=sampling_rate,
             psd_method=psd_method,
             order_criteria=order_criteria,
             normalize=normalize,
+            max_frequency=max_frequency,
         )
     return out
 
@@ -192,6 +201,7 @@ def _hrv_frequency_show(
     psd_method="welch",
     order_criteria=None,
     normalize=True,
+    max_frequency=0.5,
     **kwargs
 ):
 
@@ -217,7 +227,7 @@ def _hrv_frequency_show(
         show=False,
         min_frequency=min_frequency,
         method=psd_method,
-        max_frequency=0.5,
+        max_frequency=max_frequency,
         order_criteria=order_criteria,
         normalize=normalize,
     )


### PR DESCRIPTION
got in a muddle with GitHub, but sorted that technical issue now. so good to go I think.
I have allowed for changes in frequency bands to propagate through.  Further improvements to this could be made if requested. Trying to be ultra careful.
I note on code check that "hrv_frequency.py:14:0: W9015: "kwargs" missing in parameter documentation (missing-param-doc)" but I think this is a pre-existing warning.


# Description

I changed the hrv_frequency function to propagate through the changes to frequency bandings. Also needs a line to correct the maximum_frequency to the top of the top (VLF) banding.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [ x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [ x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [ x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)