### PR TITLE
[Fix] Avoid duplicated input sanitization in eda_process

### DIFF
--- a/neurokit2/eda/eda_process.py
+++ b/neurokit2/eda/eda_process.py
@@ -69,10 +69,6 @@ def eda_process(eda_signal, sampling_rate=1000, method="neurokit"):
     # Sanitize input
     eda_signal = signal_sanitize(eda_signal)
 
-    # Series check for non-default index
-    if isinstance(eda_signal, pd.Series) and isinstance(eda_signal.index, pd.RangeIndex):
-        eda_signal = eda_signal.reset_index(drop=True)
-
     # Preprocess
     eda_cleaned = eda_clean(eda_signal, sampling_rate=sampling_rate, method=method)
     eda_decomposed = eda_phasic(eda_cleaned, sampling_rate=sampling_rate)

--- a/neurokit2/eda/eda_process.py
+++ b/neurokit2/eda/eda_process.py
@@ -80,7 +80,7 @@ def eda_process(eda_signal, sampling_rate=1000, method="neurokit"):
         method=method,
         amplitude_min=0.1,
     )
-    info['sampling_rate'] = sampling_rate  # Add sampling rate in dict info
+    info["sampling_rate"] = sampling_rate  # Add sampling rate in dict info
 
     # Store
     signals = pd.DataFrame({"EDA_Raw": eda_signal, "EDA_Clean": eda_cleaned})


### PR DESCRIPTION
# Description

I do this PR just to eliminate the duplicity/typo of hardcoding the sanitization of the Series in the eda_process function.

# Proposed Changes

I changed the `eda_process ()` function so that only calls `signal_sanitize()`, instead of calling and sanitize immediately afterwards.


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [X] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [X] My PR is targetted at the **dev branch** (and not towards the master branch).
- [X] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)