### PR TITLE
[Docs] fix typo (sampling rate) in epochs_plot example

### DIFF
--- a/neurokit2/epochs/epochs_plot.py
+++ b/neurokit2/epochs/epochs_plot.py
@@ -35,7 +35,7 @@ def epochs_plot(epochs, legend=True, show=True, **kwargs):
       events = nk.events_find(data["Photosensor"],
                               threshold_keep='below',
                               event_conditions=["Negative", "Neutral", "Neutral", "Negative"])
-      epochs = nk.epochs_create(data, events, sampling_rate=200, epochs_end=1)
+      epochs = nk.epochs_create(data, events, sampling_rate=100, epochs_end=1)
 
       @savefig p_epochs_plot1.png scale=100%
       nk.epochs_plot(epochs)


### PR DESCRIPTION
# Description

This PR fixes a typo in the `epochs_plot()` function

# Proposed Changes

Since the sampling rate of `bio_eventrelated_100hz` is 100, I think the sampling rate passed to `epochs_create()` should be 100 instead of 200.

# Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)