### PR TITLE
[Docs] fix typo in signal_filter

### DIFF
--- a/neurokit2/signal/signal_filter.py
+++ b/neurokit2/signal/signal_filter.py
@@ -31,7 +31,6 @@ def signal_filter(
     ----------
     signal : Union[list, np.array, pd.Series]
         The signal (i.e., a time series) in the form of a vector of values.
-        or ``"bandstop"``.
     sampling_rate : int
         The sampling frequency of the signal (in Hz, i.e., samples/second).
     lowcut : float


### PR DESCRIPTION
# Description

This PR fixes a typo in the signal_filter() function.

# Proposed Changes

Since the `signal` argument does not define the filter type, I'm assuming the line I removed was a mistake.

# Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)