### PR TITLE
[Fix] Added detected rpeaks to ecg_process

### DIFF
--- a/neurokit2/ecg/ecg_process.py
+++ b/neurokit2/ecg/ecg_process.py
@@ -88,17 +88,16 @@ def ecg_process(ecg_signal, sampling_rate=1000, method="neurokit"):
 
     ecg_cleaned = ecg_clean(ecg_signal, sampling_rate=sampling_rate, method=method)
     # R-peaks
-    instant_peaks, rpeaks, = ecg_peaks(
-        ecg_cleaned=ecg_cleaned, sampling_rate=sampling_rate, method=method, correct_artifacts=True
-    )
+    (
+        instant_peaks,
+        rpeaks,
+    ) = ecg_peaks(ecg_cleaned=ecg_cleaned, sampling_rate=sampling_rate, method=method, correct_artifacts=True)
 
     rate = signal_rate(rpeaks, sampling_rate=sampling_rate, desired_length=len(ecg_cleaned))
 
-    quality = ecg_quality(ecg_cleaned, rpeaks=None, sampling_rate=sampling_rate)
+    quality = ecg_quality(ecg_cleaned, rpeaks=rpeaks["ECG_R_Peaks"], sampling_rate=sampling_rate)
 
-    signals = pd.DataFrame(
-        {"ECG_Raw": ecg_signal, "ECG_Clean": ecg_cleaned, "ECG_Rate": rate, "ECG_Quality": quality}
-    )
+    signals = pd.DataFrame({"ECG_Raw": ecg_signal, "ECG_Clean": ecg_cleaned, "ECG_Rate": rate, "ECG_Quality": quality})
 
     # Additional info of the ecg signal
     delineate_signal, delineate_info = ecg_delineate(


### PR DESCRIPTION
# Description

This PR fixes #602 . It makes such that the detected RPeaks get added to `ecg_quality`.

Runs in `docs/examples/bio_custom/bio_custom.ipynb`. May have to adapt tests.
# Proposed Changes

- `rpeaks["ECG_R_Peaks"]` is used instead of `None` for `ecq_quality`.
- Some automatic formatting

# Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)