### PR TITLE
[Docs] Fix documentation of various HRV features

### DIFF
--- a/neurokit2/complexity/entropy_multiscale.py
+++ b/neurokit2/complexity/entropy_multiscale.py
@@ -31,7 +31,7 @@ def entropy_multiscale(
     One of the limitation of :func:`SampEn <entropy_sample>` is that it characterizes
     complexity strictly on the time scale defined by the sampling procedure (via the ``delay``
     argument). To address this, Costa et al. (2002) proposed the multiscale entropy (MSEn),
-    which compute sample entropies at multiple scales.
+    which computes sample entropies at multiple scales.
 
     The conventional MSEn algorithm consists of two steps:
 

--- a/neurokit2/complexity/entropy_shannon.py
+++ b/neurokit2/complexity/entropy_shannon.py
@@ -23,8 +23,8 @@ def entropy_shannon(signal=None, base=2, symbolize=None, show=False, freq=None, 
     Because Shannon entropy was meant for symbolic sequences (discrete events such as ["A", "B",
     "B", "A"]), it does not do well with continuous signals. One option is to binarize (i.e., cut)
     the signal into a number of bins using for instance ``pd.cut(signal, bins=100, labels=False)``.
-    This can be done automatically using the ``method`` argument, which will be transferred to :
-    func:`complexity_symbolize`.
+    This can be done automatically using the ``method`` argument, which will be transferred to
+    :func:`complexity_symbolize`.
 
     This function can be called either via ``entropy_shannon()`` or ``complexity_se()``.
 

--- a/neurokit2/complexity/fractal_correlation.py
+++ b/neurokit2/complexity/fractal_correlation.py
@@ -15,8 +15,8 @@ def fractal_correlation(signal, delay=1, dimension=2, radius=64, show=False, **k
     dimension of a signal.
 
     The time series is first :func:`time-delay embedded <complexity_embedding>`, and distances
-    between all points in the trajectory are calculated. The "correlation sum" is the computed,
-    which is the proportion of pairs of points which distance is smaller than a given radius. The
+    between all points in the trajectory are calculated. The "correlation sum" is then computed,
+    which is the proportion of pairs of points whose distance is smaller than a given radius. The
     final correlation dimension is then approximated by a log-log graph of correlation sum vs. a
     sequence of radiuses.
 

--- a/neurokit2/complexity/fractal_dfa.py
+++ b/neurokit2/complexity/fractal_dfa.py
@@ -48,10 +48,10 @@ def fractal_dfa(
     singularity spectrum (MSP), and usually has shape of an inverted parabola. It measures the long
     range correlation property of a signal. From these elements, different features are extracted:
 
-    * **Width**: The width of the singularity spectrum and quantifies the degree of the
+    * **Width**: The width of the singularity spectrum, which quantifies the degree of the
       multifractality. In the case of monofractal signals, the MSP width is zero, since *h*\\(q) is
       independent of *q*.
-    * **Peak**: The value of the singularity exponent *H* corresponding to peak of
+    * **Peak**: The value of the singularity exponent *H* corresponding to the peak of
       singularity dimension *D*. It is a measure of the self-affinity of the signal, and a high
       value is an indicator of high degree of correlation between the data points. In the other
       words, the process is recurrent and repetitive.

--- a/neurokit2/hrv/hrv_frequency.py
+++ b/neurokit2/hrv/hrv_frequency.py
@@ -32,7 +32,7 @@ def hrv_frequency(
     Computes frequency domain HRV metrics, such as the power in different frequency bands.
 
     * **ULF**: The spectral power of ultra low frequencies (by default, .0 to
-      .0033 Hz) by default. Very long signals are required for this to index to be
+      .0033 Hz). Very long signals are required for this to index to be
       extracted, otherwise, will return NaN.
     * **VLF**: The spectral power of very low frequencies (by default, .0033 to .04 Hz).
     * **LF**: The spectral power of low frequencies (by default, .04 to .15 Hz).

--- a/neurokit2/hrv/hrv_nonlinear.py
+++ b/neurokit2/hrv/hrv_nonlinear.py
@@ -76,7 +76,7 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False, **kwargs):
     * **SD1d** and **SD1a**: short-term variance of contributions of decelerations (prolongations
       of RR intervals) and accelerations (shortenings of RR intervals), respectively (Piskorski,
       2011)
-    * **C1d** and **C1a**: the contributions of heart rate decelerations and accelerations to s
+    * **C1d** and **C1a**: the contributions of heart rate decelerations and accelerations to
       short-term HRV, respectively (Piskorski,  2011).
     * **SD2d** and **SD2a**: long-term variance of contributions of decelerations (prolongations of
       RR intervals) and accelerations (shortenings of RR intervals), respectively (Piskorski, 2011).
@@ -92,7 +92,7 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False, **kwargs):
     * **PIP**: Percentage of inflection points of the RR intervals series.
     * **IALS**: Inverse of the average length of the acceleration/deceleration segments.
     * **PSS**: Percentage of short segments.
-    * **PAS**: IPercentage of NN intervals in alternation segments.
+    * **PAS**: Percentage of NN intervals in alternation segments.
 
     Indices of **Complexity** and **Fractal Physiology** include:
 
@@ -106,7 +106,7 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False, **kwargs):
     * **CD**: See :func:`.fractal_correlation`.
     * **HFD**: See :func:`.fractal_higuchi` (with ``kmax`` set to ``"default"``).
     * **KFD**: See :func:`.fractal_katz`.
-    * **LZC**: See :func:`.fractal_lempelziv`.
+    * **LZC**: See :func:`.complexity_lempelziv`.
     * **DFA_alpha1**: The monofractal detrended fluctuation analysis of the HR signal,
       corresponding to short-term correlations. See :func:`.fractal_dfa`.
     * **DFA_alpha2**: The monofractal detrended fluctuation analysis of the HR signal,

--- a/neurokit2/hrv/hrv_time.py
+++ b/neurokit2/hrv/hrv_time.py
@@ -63,8 +63,6 @@ def hrv_time(peaks, sampling_rate=1000, show=False, **kwargs):
         * **CVSD**: The root mean square of the sum of successive differences (**RMSSD**) divided by
           the mean of the RR intervals (**MeanNN**).
         * **MedianNN**: The median of the RR intervals.
-        * **MedianSD**: The median of the absolute values of the successive differences between RR
-          intervals.
         * **MadNN**: The median absolute deviation of the RR intervals.
         * **MCVNN**: The median absolute deviation of the RR intervals (**MadNN**) divided by the
           median of the RR intervals (**MedianNN**).
@@ -161,7 +159,6 @@ def hrv_time(peaks, sampling_rate=1000, show=False, **kwargs):
 
     # Robust
     out["MedianNN"] = np.nanmedian(rri)
-    out["MedianSD"] = np.nanmedian(np.abs(diff_rri))
     out["MadNN"] = mad(rri)
     out["MCVNN"] = out["MadNN"] / out["MedianNN"]  # Normalized
     out["IQRNN"] = scipy.stats.iqr(rri)

--- a/neurokit2/hrv/hrv_time.py
+++ b/neurokit2/hrv/hrv_time.py
@@ -62,8 +62,7 @@ def hrv_time(peaks, sampling_rate=1000, show=False, **kwargs):
           the RR intervals (**MeanNN**).
         * **CVSD**: The root mean square of the sum of successive differences (**RMSSD**) divided by
           the mean of the RR intervals (**MeanNN**).
-        * **MedianNN**: The median of the absolute values of the successive differences between RR
-          intervals.
+        * **MedianNN**: The median of the RR intervals.
         * **MadNN**: The median absolute deviation of the RR intervals.
         * **MCVNN**: The median absolute deviation of the RR intervals (**MadNN**) divided by the
           median of the absolute differences of their successive differences (**MedianNN**).

--- a/neurokit2/hrv/hrv_time.py
+++ b/neurokit2/hrv/hrv_time.py
@@ -63,6 +63,8 @@ def hrv_time(peaks, sampling_rate=1000, show=False, **kwargs):
         * **CVSD**: The root mean square of the sum of successive differences (**RMSSD**) divided by
           the mean of the RR intervals (**MeanNN**).
         * **MedianNN**: The median of the RR intervals.
+        * **MedianSD**: The median of the absolute values of the successive differences between RR
+          intervals.
         * **MadNN**: The median absolute deviation of the RR intervals.
         * **MCVNN**: The median absolute deviation of the RR intervals (**MadNN**) divided by the
           median of the RR intervals (**MedianNN**).
@@ -159,6 +161,7 @@ def hrv_time(peaks, sampling_rate=1000, show=False, **kwargs):
 
     # Robust
     out["MedianNN"] = np.nanmedian(rri)
+    out["MedianSD"] = np.nanmedian(np.abs(diff_rri))
     out["MadNN"] = mad(rri)
     out["MCVNN"] = out["MadNN"] / out["MedianNN"]  # Normalized
     out["IQRNN"] = scipy.stats.iqr(rri)

--- a/neurokit2/hrv/hrv_time.py
+++ b/neurokit2/hrv/hrv_time.py
@@ -65,7 +65,7 @@ def hrv_time(peaks, sampling_rate=1000, show=False, **kwargs):
         * **MedianNN**: The median of the RR intervals.
         * **MadNN**: The median absolute deviation of the RR intervals.
         * **MCVNN**: The median absolute deviation of the RR intervals (**MadNN**) divided by the
-          median of the absolute differences of their successive differences (**MedianNN**).
+          median of the RR intervals (**MedianNN**).
         * **IQRNN**: The interquartile range (**IQR**) of the RR intervals.
         * **Prc20NN**: The 20th percentile of the RR intervals (Han, 2017; Hovsepian, 2015).
         * **Prc80NN**: The 80th percentile of the RR intervals (Han, 2017; Hovsepian, 2015).


### PR DESCRIPTION
# Description

~~Modify the `hrv_time()` function such that the documentation for `MedianNN` reflects what is actually computed and implement the previous description of MedianNN: The median of the absolute values of the successive differences between RR intervals.~~
I corrected some errors in the documentation of `hrv_time()`, `hrv_frequency()`, `hrv_nonlinear()`, `entropy_shannon()`, `entropy_multiscale()`, `fractal_correlation()`, and `fractal_dfa()`.

# Proposed Changes

I changed the `hrv_time()` function as follows:
1. Changed documentation of `MedianNN` and `MCVNN`

~~2. Added `MedianSD` (wasn't sure about the name) as a feature: The median of the absolute values of the successive differences between RR intervals.~~
I also made small changes to the documentation of `hrv_frequency()`, `hrv_nonlinear()`, `entropy_shannon()`, `entropy_multiscale()`, `fractal_correlation()`, and `fractal_dfa()`.

# Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
`astroid.exceptions.TooManyLevelsError: Relative import with too many levels (2) for module 'hrv_time'` I don't think I caused this
- [ ] I have added the newly added features to **News.rst** (if applicable)