### PR TITLE
[Fix] allow for bandstop filtering in signal_filter()

### DIFF
--- a/neurokit2/signal/signal_filter.py
+++ b/neurokit2/signal/signal_filter.py
@@ -151,9 +151,7 @@ def signal_filter(
 
         # Sanity checks
         if lowcut is None and highcut is None:
-            raise ValueError(
-                "NeuroKit error: signal_filter(): you need to specify a 'lowcut' or a 'highcut'."
-            )
+            raise ValueError("NeuroKit error: signal_filter(): you need to specify a 'lowcut' or a 'highcut'.")
 
         if method in ["butter", "butterworth"]:
             filtered = _signal_filter_butterworth(signal, sampling_rate, lowcut, highcut, order)
@@ -162,9 +160,7 @@ def signal_filter(
         elif method in ["bessel"]:
             filtered = _signal_filter_bessel(signal, sampling_rate, lowcut, highcut, order)
         elif method in ["fir"]:
-            filtered = _signal_filter_fir(
-                signal, sampling_rate, lowcut, highcut, window_size=window_size
-            )
+            filtered = _signal_filter_fir(signal, sampling_rate, lowcut, highcut, window_size=window_size)
         else:
             raise ValueError(
                 "NeuroKit error: signal_filter(): 'method' should be",
@@ -203,9 +199,7 @@ def _signal_filter_savgol(signal, sampling_rate=1000, order=2, window_size="defa
 # =============================================================================
 # FIR
 # =============================================================================
-def _signal_filter_fir(
-    signal, sampling_rate=1000, lowcut=None, highcut=None, window_size="default"
-):
+def _signal_filter_fir(signal, sampling_rate=1000, lowcut=None, highcut=None, window_size="default"):
     """Filter a signal using a FIR filter."""
     try:
         import mne
@@ -243,9 +237,7 @@ def _signal_filter_fir(
 
 def _signal_filter_butterworth(signal, sampling_rate=1000, lowcut=None, highcut=None, order=5):
     """Filter a signal using IIR Butterworth SOS method."""
-    freqs, filter_type = _signal_filter_sanitize(
-        lowcut=lowcut, highcut=highcut, sampling_rate=sampling_rate
-    )
+    freqs, filter_type = _signal_filter_sanitize(lowcut=lowcut, highcut=highcut, sampling_rate=sampling_rate)
 
     sos = scipy.signal.butter(order, freqs, btype=filter_type, output="sos", fs=sampling_rate)
     filtered = scipy.signal.sosfiltfilt(sos, signal)
@@ -255,9 +247,7 @@ def _signal_filter_butterworth(signal, sampling_rate=1000, lowcut=None, highcut=
 def _signal_filter_butterworth_ba(signal, sampling_rate=1000, lowcut=None, highcut=None, order=5):
     """Filter a signal using IIR Butterworth B/A method."""
     # Get coefficients
-    freqs, filter_type = _signal_filter_sanitize(
-        lowcut=lowcut, highcut=highcut, sampling_rate=sampling_rate
-    )
+    freqs, filter_type = _signal_filter_sanitize(lowcut=lowcut, highcut=highcut, sampling_rate=sampling_rate)
 
     b, a = scipy.signal.butter(order, freqs, btype=filter_type, output="ba", fs=sampling_rate)
     try:
@@ -274,9 +264,7 @@ def _signal_filter_butterworth_ba(signal, sampling_rate=1000, lowcut=None, highc
 
 
 def _signal_filter_bessel(signal, sampling_rate=1000, lowcut=None, highcut=None, order=5):
-    freqs, filter_type = _signal_filter_sanitize(
-        lowcut=lowcut, highcut=highcut, sampling_rate=sampling_rate
-    )
+    freqs, filter_type = _signal_filter_sanitize(lowcut=lowcut, highcut=highcut, sampling_rate=sampling_rate)
 
     sos = scipy.signal.bessel(order, freqs, btype=filter_type, output="sos", fs=sampling_rate)
     filtered = scipy.signal.sosfiltfilt(sos, signal)

--- a/neurokit2/signal/signal_filter.py
+++ b/neurokit2/signal/signal_filter.py
@@ -238,7 +238,6 @@ def _signal_filter_fir(signal, sampling_rate=1000, lowcut=None, highcut=None, wi
 def _signal_filter_butterworth(signal, sampling_rate=1000, lowcut=None, highcut=None, order=5):
     """Filter a signal using IIR Butterworth SOS method."""
     freqs, filter_type = _signal_filter_sanitize(lowcut=lowcut, highcut=highcut, sampling_rate=sampling_rate)
-
     sos = scipy.signal.butter(order, freqs, btype=filter_type, output="sos", fs=sampling_rate)
     filtered = scipy.signal.sosfiltfilt(sos, signal)
     return filtered
@@ -296,7 +295,7 @@ def _signal_filter_sanitize(lowcut=None, highcut=None, sampling_rate=1000, norma
 
     # Sanity checks
     if lowcut is not None or highcut is not None:
-        if sampling_rate <= 2 * np.max(np.array([lowcut, highcut], dtype=np.float64)):
+        if sampling_rate <= 2 * np.nanmax(np.array([lowcut, highcut], dtype=np.float64)):
             warn(
                 "The sampling rate is too low. Sampling rate"
                 " must exceed the Nyquist rate to avoid aliasing problem."

--- a/neurokit2/signal/signal_filter.py
+++ b/neurokit2/signal/signal_filter.py
@@ -296,7 +296,7 @@ def _signal_filter_sanitize(lowcut=None, highcut=None, sampling_rate=1000, norma
 
     # Sanity checks
     if lowcut is not None or highcut is not None:
-        if sampling_rate <= 2 * np.max([lowcut, highcut]):
+        if sampling_rate <= 2 * np.max(np.array([lowcut, highcut], dtype=np.float64)):
             warn(
                 "The sampling rate is too low. Sampling rate"
                 " must exceed the Nyquist rate to avoid aliasing problem."

--- a/neurokit2/signal/signal_filter.py
+++ b/neurokit2/signal/signal_filter.py
@@ -296,7 +296,7 @@ def _signal_filter_sanitize(lowcut=None, highcut=None, sampling_rate=1000, norma
 
     # Sanity checks
     if lowcut is not None or highcut is not None:
-        if sampling_rate <= 2 * np.max(lowcut, highcut):
+        if sampling_rate <= 2 * np.max([lowcut, highcut]):
             warn(
                 "The sampling rate is too low. Sampling rate"
                 " must exceed the Nyquist rate to avoid aliasing problem."

--- a/neurokit2/signal/signal_filter.py
+++ b/neurokit2/signal/signal_filter.py
@@ -328,7 +328,8 @@ def _signal_filter_sanitize(lowcut=None, highcut=None, sampling_rate=1000, norma
             filter_type = "bandstop"
         else:
             filter_type = "bandpass"
-        freqs = [lowcut, highcut]
+        # pass frequencies in order of lowest to highest to the scipy filter
+        freqs = list(np.sort([lowcut, highcut]))
     elif lowcut is not None:
         freqs = [lowcut]
         filter_type = "highpass"

--- a/neurokit2/signal/signal_filter.py
+++ b/neurokit2/signal/signal_filter.py
@@ -307,8 +307,8 @@ def _signal_filter_powerline(signal, sampling_rate, powerline=50):
 def _signal_filter_sanitize(lowcut=None, highcut=None, sampling_rate=1000, normalize=False):
 
     # Sanity checks
-    if isinstance(highcut, int):
-        if sampling_rate <= 2 * highcut:
+    if lowcut is not None or highcut is not None:
+        if sampling_rate <= 2 * np.max(lowcut, highcut):
             warn(
                 "The sampling rate is too low. Sampling rate"
                 " must exceed the Nyquist rate to avoid aliasing problem."

--- a/tests/tests_signal.py
+++ b/tests/tests_signal.py
@@ -159,6 +159,12 @@ def test_signal_filter():
 
     assert np.allclose(sum(signal_clean - signal), -2, atol=0.2)
 
+    signal_bandstop = nk.signal_filter(
+        signal_corrupted, sampling_rate=sampling_rate, lowcut=52, highcut=48
+    )
+
+    assert np.allclose(sum(signal_bandstop - signal), -2, atol=0.2)
+
 
 def test_signal_interpolate():
 

--- a/tests/tests_signal.py
+++ b/tests/tests_signal.py
@@ -156,14 +156,34 @@ def test_signal_filter():
     # ax0.plot(signal_corrupted)
     # ax1.plot(signal)
     # ax2.plot(signal_clean * 100)
+    # plt.suptitle("Powerline")
+    # plt.show()
 
     assert np.allclose(sum(signal_clean - signal), -2, atol=0.2)
 
+    lowcut = 60
+    highcut = 40
+    order = 2
+
     signal_bandstop = nk.signal_filter(
-        signal_corrupted, sampling_rate=sampling_rate, lowcut=52, highcut=48
+        signal_corrupted, sampling_rate=sampling_rate, lowcut=lowcut, highcut=highcut, method="butterworth",
+        order=order
     )
 
-    assert np.allclose(sum(signal_bandstop - signal), -2, atol=0.2)
+    freqs = [highcut, lowcut]
+    filter_type = "bandstop"
+    sos = scipy.signal.butter(order, freqs, btype=filter_type, output="sos", fs=sampling_rate)
+    signal_bandstop_scipy = scipy.signal.sosfiltfilt(sos, signal_corrupted)
+
+    # figure, (ax0, ax1, ax2, ax3) = plt.subplots(nrows=4, ncols=1, sharex=True)
+    # ax0.plot(signal_corrupted)
+    # ax1.plot(signal)
+    # ax2.plot(signal_bandstop * 100)
+    # ax3.plot(signal_bandstop_scipy * 100)
+    # plt.suptitle("Bandstop")
+    # plt.show()
+
+    assert np.allclose(signal_bandstop, signal_bandstop_scipy, atol=0.2)
 
 
 def test_signal_interpolate():


### PR DESCRIPTION
# Description

This PR aims at adding the ability to bandstop filter. See also https://github.com/neuropsychology/NeuroKit/issues/685

# Proposed Changes

I changed the `signal_filter()` function so that if `lowcut` is higher than `highcut`, the filter type passed is `bandstop`.


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)