### PR TITLE
[Feature] use lombscargle PSD method without interpolation

### DIFF
--- a/neurokit2/hrv/hrv_frequency.py
+++ b/neurokit2/hrv/hrv_frequency.py
@@ -92,6 +92,8 @@ def hrv_frequency(
     interpolation_rate : int, optional
         Sampling rate (Hz) of the interpolated interbeat intervals. Should be at least twice as
         high as the highest frequency in vhf. By default 100. To replicate Kubios defaults, set to 4.
+        To not interpolate, set interpolation_rate to None (in case the interbeat intervals are already
+        interpolated or when using the ``"lombscargle"`` psd_method for which interpolation is not required).
     **kwargs
         Additional other arguments.
 
@@ -170,6 +172,11 @@ def hrv_frequency(
         rri, intervals_time=rri_time, interpolate=True, interpolation_rate=interpolation_rate, **kwargs
     )
 
+    if interpolation_rate is None:
+        t = rri_time
+    else:
+        t = None
+
     frequency_band = [ulf, vlf, lf, hf, vhf]
 
     # Find maximum frequency
@@ -184,6 +191,7 @@ def hrv_frequency(
         show=False,
         normalize=normalize,
         order_criteria=order_criteria,
+        t=t,
         **kwargs
     )
 
@@ -228,6 +236,7 @@ def hrv_frequency(
             order_criteria=order_criteria,
             normalize=normalize,
             max_frequency=max_frequency,
+            t=t,
         )
     return out
 
@@ -245,6 +254,7 @@ def _hrv_frequency_show(
     order_criteria=None,
     normalize=True,
     max_frequency=0.5,
+    t=None,
     **kwargs
 ):
 
@@ -273,6 +283,7 @@ def _hrv_frequency_show(
         max_frequency=max_frequency,
         order_criteria=order_criteria,
         normalize=normalize,
+        t=t,
     )
 
     _signal_power_instant_plot(psd, out_bands, frequency_band, ax=ax)

--- a/neurokit2/hrv/intervals_preprocess.py
+++ b/neurokit2/hrv/intervals_preprocess.py
@@ -4,7 +4,7 @@ from warnings import warn
 import numpy as np
 
 from ..signal import signal_interpolate
-from .hrv_utils import _intervals_sanitize
+from .hrv_utils import _intervals_sanitize, _intervals_time_uniform, _intervals_time_to_sampling_rate
 
 from ..misc import NeuroKitWarning
 
@@ -39,7 +39,7 @@ def intervals_preprocess(intervals, intervals_time=None, interpolate=False, inte
     if interpolate is False:
         interpolation_rate = None
 
-    else:
+    if interpolation_rate is not None:
         # Rate should be at least 1 Hz (due to Nyquist & frequencies we are interested in)
         # We considered an interpolation rate 4 Hz by default to match Kubios
         # but in case of some applications with high heart rates we decided to make it 100 Hz
@@ -61,4 +61,9 @@ def intervals_preprocess(intervals, intervals_time=None, interpolate=False, inte
         )
 
         intervals = signal_interpolate(intervals_time, intervals, x_new=x_new, **kwargs)
+    else:
+        # check if intervals appear to be already interpolated
+        if _intervals_time_uniform(intervals_time):
+            # get sampling rate used for interpolation
+            interpolation_rate = _intervals_time_to_sampling_rate(intervals_time)
     return intervals, interpolation_rate

--- a/neurokit2/hrv/intervals_preprocess.py
+++ b/neurokit2/hrv/intervals_preprocess.py
@@ -3,10 +3,9 @@ from warnings import warn
 
 import numpy as np
 
-from ..signal import signal_interpolate
-from .hrv_utils import _intervals_sanitize, _intervals_time_uniform, _intervals_time_to_sampling_rate
-
 from ..misc import NeuroKitWarning
+from ..signal import signal_interpolate
+from .intervals_utils import _intervals_sanitize, _intervals_time_to_sampling_rate, _intervals_time_uniform
 
 
 def intervals_preprocess(intervals, intervals_time=None, interpolate=False, interpolation_rate=100, **kwargs):
@@ -55,9 +54,7 @@ def intervals_preprocess(intervals, intervals_time=None, interpolate=False, inte
 
         # Compute x-values of interpolated interval signal at requested sampling rate.
         x_new = np.arange(
-            start=intervals_time[0],
-            stop=intervals_time[-1] + 1 / interpolation_rate,
-            step=1 / interpolation_rate,
+            start=intervals_time[0], stop=intervals_time[-1] + 1 / interpolation_rate, step=1 / interpolation_rate,
         )
 
         intervals = signal_interpolate(intervals_time, intervals, x_new=x_new, **kwargs)

--- a/neurokit2/hrv/intervals_process.py
+++ b/neurokit2/hrv/intervals_process.py
@@ -17,7 +17,7 @@ def intervals_process(
     intervals_time=None,
     interpolate=False,
     interpolation_rate=100,
-    detrend_method=None,
+    detrend=None,
     **kwargs
 ):
     """**Interval preprocessing**
@@ -33,7 +33,7 @@ def intervals_process(
     interpolation_rate : int, optional
         Sampling rate (Hz) of the interpolated interbeat intervals. Should be at least twice as
         high as the highest frequency in vhf. By default 100. To replicate Kubios defaults, set to 4.
-    detrend_method : str
+    detrend : str
         Can be one of ``"polynomial"`` (traditional detrending of a given order) or
         ``"tarvainen2002"`` to use the smoothness priors approach described by Tarvainen (2002)
         (mostly used in HRV analyses as a lowpass filter to remove complex trends), ``"loess"`` for
@@ -72,7 +72,7 @@ def intervals_process(
                                                       intervals_time=rri_time,
                                                       interpolate=True,
                                                       interpolation_rate=100,
-                                                      detrend_method="tarvainen2002")
+                                                      detrend="tarvainen2002")
       plt.plot(intervals_time, intervals, label="Processed intervals")
       plt.xlabel("Time (seconds)")
       plt.ylabel("Interbeat intervals (milliseconds)")
@@ -114,6 +114,6 @@ def intervals_process(
             # get sampling rate used for interpolation
             interpolation_rate = _intervals_time_to_sampling_rate(intervals_time)
 
-    if detrend_method is not None:
-        intervals = signal_detrend(intervals, method=detrend_method)
+    if detrend is not None:
+        intervals = signal_detrend(intervals, method=detrend)
     return intervals, interpolation_rate

--- a/neurokit2/hrv/intervals_utils.py
+++ b/neurokit2/hrv/intervals_utils.py
@@ -58,9 +58,7 @@ def _intervals_successive(intervals, intervals_time=None, thresh_unequal=2, n_di
 
     diff_intervals_time_ms = np.diff(intervals_time, n=n_diff) * 1000
 
-    abs_error_intervals_ref_time = abs(
-        diff_intervals_time_ms - np.diff(intervals[1:], n=n_diff - 1)
-    )
+    abs_error_intervals_ref_time = abs(diff_intervals_time_ms - np.diff(intervals[1:], n=n_diff - 1))
 
     successive_intervals = abs_error_intervals_ref_time <= thresh_unequal
 
@@ -68,7 +66,7 @@ def _intervals_successive(intervals, intervals_time=None, thresh_unequal=2, n_di
 
 
 def _intervals_time_uniform(intervals_time, decimals=3):
-    """Check whether timestamps are uniformly spaced
+    """Check whether timestamps are uniformly spaced.
 
     Useful for determining whether intervals have been interpolated.
 
@@ -83,6 +81,7 @@ def _intervals_time_uniform(intervals_time, decimals=3):
     ----------
     bool
         Whether the timestamps are uniformly spaced
+
     """
     return len(np.unique(np.round(np.diff(intervals_time), decimals=decimals))) == 1
 
@@ -137,9 +136,7 @@ def _intervals_sanitize(intervals, intervals_time=None, remove_missing=True):
                 # If none of the differences between timestamps match
                 # the length of the R-R intervals in seconds,
                 # try converting milliseconds to seconds
-                converted_successive_intervals = _intervals_successive(
-                    intervals, intervals_time=intervals_time / 1000
-                )
+                converted_successive_intervals = _intervals_successive(intervals, intervals_time=intervals_time / 1000)
 
                 # Check if converting to seconds increased the number of differences
                 # between timestamps that match the length of the R-R intervals in seconds
@@ -156,10 +153,8 @@ def _intervals_sanitize(intervals, intervals_time=None, remove_missing=True):
     return intervals, intervals_time
 
 
-def _intervals_time_to_sampling_rate(
-    intervals_time, central_measure="mean"
-):
-    """Get sampling rate from timestamps
+def _intervals_time_to_sampling_rate(intervals_time, central_measure="mean"):
+    """Get sampling rate from timestamps.
 
     Useful for determining sampling rate used to interpolate intervals.
 
@@ -174,6 +169,7 @@ def _intervals_time_to_sampling_rate(
     ----------
     bool
         Whether the timestamps are uniformly spaced
+
     """
     if central_measure == "mean":
         sampling_rate = float(1 / np.nanmean(np.diff(intervals_time)))

--- a/neurokit2/signal/signal_psd.py
+++ b/neurokit2/signal/signal_psd.py
@@ -142,10 +142,7 @@ def signal_psd(
     # MNE
     if method in ["multitaper", "multitapers", "mne"]:
         frequency, power = _signal_psd_multitaper(
-            signal,
-            sampling_rate=sampling_rate,
-            min_frequency=min_frequency,
-            max_frequency=max_frequency,
+            signal, sampling_rate=sampling_rate, min_frequency=min_frequency, max_frequency=max_frequency,
         )
 
     # FFT (Numpy)
@@ -155,11 +152,7 @@ def signal_psd(
     # Lombscargle (AtroPy)
     elif method.lower() in ["lombscargle", "lomb"]:
         frequency, power = _signal_psd_lomb(
-            signal,
-            sampling_rate=sampling_rate,
-            min_frequency=min_frequency,
-            max_frequency=max_frequency,
-            t=t
+            signal, sampling_rate=sampling_rate, min_frequency=min_frequency, max_frequency=max_frequency, t=t
         )
 
     # Method that are using a window
@@ -188,11 +181,7 @@ def signal_psd(
         # Welch (Scipy)
         if method.lower() in ["welch"]:
             frequency, power = _signal_psd_welch(
-                signal,
-                sampling_rate=sampling_rate,
-                nperseg=nperseg,
-                window_type=window_type,
-                **kwargs,
+                signal, sampling_rate=sampling_rate, nperseg=nperseg, window_type=window_type, **kwargs,
             )
 
         # BURG
@@ -215,15 +204,11 @@ def signal_psd(
     data = pd.DataFrame({"Frequency": frequency, "Power": power})
 
     # Filter
-    data = data.loc[
-        np.logical_and(data["Frequency"] >= min_frequency, data["Frequency"] <= max_frequency)
-    ]
+    data = data.loc[np.logical_and(data["Frequency"] >= min_frequency, data["Frequency"] <= max_frequency)]
     #    data["Power"] = 10 * np.log(data["Power"])
 
     if show is True:
-        ax = data.plot(
-            x="Frequency", y="Power", title="Power Spectral Density (" + str(method) + " method)"
-        )
+        ax = data.plot(x="Frequency", y="Power", title="Power Spectral Density (" + str(method) + " method)")
         ax.set(xlabel="Frequency (Hz)", ylabel="Spectrum")
 
     return data
@@ -304,6 +289,7 @@ def _signal_psd_lomb(signal, sampling_rate=1000, min_frequency=0, max_frequency=
 
     try:
         import astropy.timeseries
+
         if t is None:
             if max_frequency == np.inf:
                 max_frequency = sampling_rate / 2  # sanitize highest frequency
@@ -334,13 +320,7 @@ def _signal_psd_lomb(signal, sampling_rate=1000, min_frequency=0, max_frequency=
 
 
 def _signal_psd_burg(
-    signal,
-    sampling_rate=1000,
-    order=16,
-    criteria="KIC",
-    corrected=True,
-    side="one-sided",
-    nperseg=None,
+    signal, sampling_rate=1000, order=16, criteria="KIC", corrected=True, side="one-sided", nperseg=None,
 ):
 
     nfft = int(nperseg * 2)
@@ -410,9 +390,7 @@ def _signal_arma_burg(signal, order=16, criteria="KIC", corrected=True):
 
         if criteria is not None:
             # k=k+1 because order goes from 1 to P whereas k starts at 0.
-            residual_new = _criteria(
-                criteria=criteria, N=N, k=k + 1, rho=new_rho, corrected=corrected
-            )
+            residual_new = _criteria(criteria=criteria, N=N, k=k + 1, rho=new_rho, corrected=corrected)
             if k == 0:
                 residual_old = 2.0 * abs(residual_new)
 
@@ -424,9 +402,7 @@ def _signal_arma_burg(signal, order=16, criteria="KIC", corrected=True):
             residual_old = residual_new
         rho = new_rho
         if rho <= 0:
-            raise ValueError(
-                f"Found a negative value (expected positive strictly) {rho}. Decrease the order."
-            )
+            raise ValueError(f"Found a negative value (expected positive strictly) {rho}. Decrease the order.")
 
         ar = np.resize(ar, ar.size + 1)
         ar[k] = kp
@@ -501,9 +477,7 @@ def _criteria(criteria=None, N=None, k=None, rho=None, corrected=True):
 
     elif criteria == "KIC":
         if corrected is True:
-            residual = (
-                np.log(rho) + k / N / (N - k) + (3.0 - (k + 2.0) / N) * (k + 1.0) / (N - k - 2.0)
-            )
+            residual = np.log(rho) + k / N / (N - k) + (3.0 - (k + 2.0) / N) * (k + 1.0) / (N - k - 2.0)
         else:
             residual = np.log(rho) + 3.0 * (k + 1.0) / float(N)
 
@@ -518,9 +492,7 @@ def _criteria(criteria=None, N=None, k=None, rho=None, corrected=True):
     return residual
 
 
-def _signal_psd_from_arma(
-    ar=None, ma=None, rho=1.0, sampling_rate=1000, nfft=None, side="one-sided"
-):
+def _signal_psd_from_arma(ar=None, ma=None, rho=1.0, sampling_rate=1000, nfft=None, side="one-sided"):
 
     if ar is None and ma is None:
         raise ValueError("Either AR or MA model must be provided")


### PR DESCRIPTION
# Description
This PR aims to add the ability to use the lombscargle PSD method without interpolating the signal, i.e., so that (possibly unevenly spaced) timestamps can be directly used. See also  https://github.com/neuropsychology/NeuroKit/issues/671#issuecomment-1192153962

# Proposed Changes

1. I changed the `hrv_frequency()` function so that the timestamps `t` are passed as an argument to `signal_psd()` if the `interpolation_rate` argument is set to `None`
2. I added the timestamps `t` as an argument to `signal_psd()` so they can be passed to `_signal_psd_lomb()`
3. I added functions to check whether the timestamps were already interpolated to be evenly spaced (`_intervals_time_uniform()`) and if so, determine their sampling rate (`_intervals_time_to_sampling_rate()`), so that the user can pass interpolated R-R intervals to `hrv_frequency()` and these are still treated as interpolated by `signal_psd()`.


# Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)