### PR TITLE
[Breaking] entropy_multiscale(): default dimension is now 3 instead of 2

### DIFF
--- a/neurokit2/complexity/entropy_multiscale.py
+++ b/neurokit2/complexity/entropy_multiscale.py
@@ -20,7 +20,7 @@ from .utils_complexity_coarsegraining import _get_scales, complexity_coarsegrain
 def entropy_multiscale(
     signal,
     scale="default",
-    dimension=2,
+    dimension=3,
     tolerance="sd",
     method="MSEn",
     show=False,
@@ -242,11 +242,9 @@ def entropy_multiscale(
     """
     # Sanity checks
     if isinstance(signal, (np.ndarray, pd.DataFrame)) and signal.ndim > 1:
-        raise ValueError(
-            "Multidimensional inputs (e.g., matrices or multichannel data) are not supported yet."
-        )
+        raise ValueError("Multidimensional inputs (e.g., matrices or multichannel data) are not supported yet.")
     # Prevent multiple arguments error in case 'delay' is passed in kwargs
-    if "delay" in kwargs.keys():
+    if "delay" in kwargs:
         kwargs.pop("delay")
 
     # Parameters selection
@@ -361,7 +359,6 @@ def entropy_multiscale(
 # Internal
 # =============================================================================
 def _entropy_multiscale_plot(mse, info):
-
     fig = plt.figure(constrained_layout=False)
     fig.suptitle("Entropy values across scale factors")
     plt.title(f"(Total {info['Method']} = {np.round(mse, 3)})")
@@ -426,7 +423,7 @@ def _entropy_multiscale(coarse, algorithm, dimension, tolerance, refined=False, 
 
 
 def _validmean(x):
-    """Mean that is robust to NaN and Inf"""
+    """Mean that is robust to NaN and Inf."""
     x = np.array(x)[np.isfinite(x)]
     if len(x) == 0:
         return np.nan


### PR DESCRIPTION
# Description

Default dimension parameters for entropy functions should be 3 as discussed in #714 

# Proposed Changes

- Changed the default behaviour in `entropy_multiscale()` function for the dimension parameter from 2 to 3.
- Minor formatting and code style changes.

# Questions

Should this be included in **News.rst**?
Is `entropy_multiscale()` used else where? Or should the parameter be updated elsewhere?

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)