### PR TITLE
[Feature] adjust HRV functions for missing intervals

### DIFF
--- a/neurokit2/hrv/hrv.py
+++ b/neurokit2/hrv/hrv.py
@@ -151,12 +151,12 @@ def _hrv_plot(peaks, out, sampling_rate=1000, interpolation_rate=100, **kwargs):
     plt.tight_layout(h_pad=0.5, w_pad=0.5)
 
     # Distribution of RR intervals
-    rri, rri_time, _ = _hrv_format_input(peaks, sampling_rate=sampling_rate)
+    rri, rri_time, rri_missing = _hrv_format_input(peaks, sampling_rate=sampling_rate)
     ax_distrib = summary_plot(rri, ax=ax_distrib, **kwargs)
 
     # Poincare plot
     out.columns = [col.replace("HRV_", "") for col in out.columns]
-    _hrv_nonlinear_show(rri, out, ax=ax_poincare, ax_marg_x=ax_marg_x, ax_marg_y=ax_marg_y)
+    _hrv_nonlinear_show(rri, rri_time=rri_time, rri_missing=rri_missing, out=out, ax=ax_poincare, ax_marg_x=ax_marg_x, ax_marg_y=ax_marg_y)
 
     # PSD plot
     rri, sampling_rate = intervals_process(

--- a/neurokit2/hrv/hrv.py
+++ b/neurokit2/hrv/hrv.py
@@ -151,7 +151,7 @@ def _hrv_plot(peaks, out, sampling_rate=1000, interpolation_rate=100, **kwargs):
     plt.tight_layout(h_pad=0.5, w_pad=0.5)
 
     # Distribution of RR intervals
-    rri, rri_time = _hrv_format_input(peaks, sampling_rate=sampling_rate)
+    rri, rri_time, _ = _hrv_format_input(peaks, sampling_rate=sampling_rate)
     ax_distrib = summary_plot(rri, ax=ax_distrib, **kwargs)
 
     # Poincare plot

--- a/neurokit2/hrv/hrv.py
+++ b/neurokit2/hrv/hrv.py
@@ -159,7 +159,7 @@ def _hrv_plot(peaks, out, sampling_rate=1000, interpolation_rate=100, **kwargs):
     _hrv_nonlinear_show(rri, rri_time=rri_time, rri_missing=rri_missing, out=out, ax=ax_poincare, ax_marg_x=ax_marg_x, ax_marg_y=ax_marg_y)
 
     # PSD plot
-    rri, sampling_rate = intervals_process(
+    rri, rri_time, sampling_rate = intervals_process(
         rri, intervals_time=rri_time, interpolate=True, interpolation_rate=interpolation_rate, **kwargs
     )
 

--- a/neurokit2/hrv/hrv_frequency.py
+++ b/neurokit2/hrv/hrv_frequency.py
@@ -168,7 +168,7 @@ def hrv_frequency(
     rri, rri_time, _ = _hrv_format_input(peaks, sampling_rate=sampling_rate)
 
     # Process R-R intervals (interpolated at 100 Hz by default)
-    rri, sampling_rate = intervals_process(
+    rri, rri_time, sampling_rate = intervals_process(
         rri, intervals_time=rri_time, interpolate=True, interpolation_rate=interpolation_rate, **kwargs
     )
 

--- a/neurokit2/hrv/hrv_frequency.py
+++ b/neurokit2/hrv/hrv_frequency.py
@@ -165,7 +165,7 @@ def hrv_frequency(
 
     # Sanitize input
     # If given peaks, compute R-R intervals (also referred to as NN) in milliseconds
-    rri, rri_time = _hrv_format_input(peaks, sampling_rate=sampling_rate)
+    rri, rri_time, _ = _hrv_format_input(peaks, sampling_rate=sampling_rate)
 
     # Process R-R intervals (interpolated at 100 Hz by default)
     rri, sampling_rate = intervals_process(

--- a/neurokit2/hrv/hrv_nonlinear.py
+++ b/neurokit2/hrv/hrv_nonlinear.py
@@ -22,6 +22,7 @@ from ..complexity import (
 from ..misc import NeuroKitWarning, find_consecutive
 from ..signal import signal_zerocrossings
 from .hrv_utils import _hrv_format_input
+from .intervals_utils import _intervals_successive
 
 
 def hrv_nonlinear(peaks, sampling_rate=1000, show=False, **kwargs):
@@ -206,19 +207,26 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False, **kwargs):
     """
     # Sanitize input
     # If given peaks, compute R-R intervals (also referred to as NN) in milliseconds
-    rri, _, _ = _hrv_format_input(peaks, sampling_rate=sampling_rate)
-
+    rri, rri_time, rri_missing = _hrv_format_input(peaks, sampling_rate=sampling_rate)
+    
+    if rri_missing:
+        warn(
+            "Missing interbeat intervals have been detected. "
+            "Note that missing intervals can distort some HRV features, in particular "
+            "nonlinear indices.",
+            category=NeuroKitWarning,
+        )
     # Initialize empty container for results
     out = {}
 
     # Poincaré features (SD1, SD2, etc.)
-    out = _hrv_nonlinear_poincare(rri, out)
+    out = _hrv_nonlinear_poincare(rri, rri_time=rri_time, rri_missing=rri_missing, out=out)
 
     # Heart Rate Fragmentation
-    out = _hrv_nonlinear_fragmentation(rri, out)
+    out = _hrv_nonlinear_fragmentation(rri, rri_time=rri_time, rri_missing=rri_missing, out=out)
 
     # Heart Rate Asymmetry
-    out = _hrv_nonlinear_poincare_hra(rri, out)
+    out = _hrv_nonlinear_poincare_hra(rri, rri_time=rri_time, rri_missing=rri_missing, out=out)
 
     # DFA
     out = _hrv_dfa(rri, out, **kwargs)
@@ -239,7 +247,7 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False, **kwargs):
     out["LZC"], _ = complexity_lempelziv(rri, **kwargs)
 
     if show:
-        _hrv_nonlinear_show(rri, out)
+        _hrv_nonlinear_show(rri, rri_time=rri_time, rri_missing=rri_missing, out=out)
 
     out = pd.DataFrame.from_dict(out, orient="index").T.add_prefix("HRV_")
     return out
@@ -248,7 +256,7 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False, **kwargs):
 # =============================================================================
 # Get SD1 and SD2
 # =============================================================================
-def _hrv_nonlinear_poincare(rri, out):
+def _hrv_nonlinear_poincare(rri, rri_time=None, rri_missing=False, out={}):
     """Compute SD1 and SD2.
 
     - Brennan (2001). Do existing measures of Poincare plot geometry reflect nonlinear features of
@@ -259,6 +267,13 @@ def _hrv_nonlinear_poincare(rri, out):
     # HRV and hrvanalysis
     rri_n = rri[:-1]
     rri_plus = rri[1:]
+    
+    if rri_missing:
+        # Only include successive differences
+        rri_plus = rri_plus[_intervals_successive(rri, intervals_time=rri_time)]
+        rri_n = rri_n[_intervals_successive(rri, intervals_time=rri_time)]
+
+    
     x1 = (rri_n - rri_plus) / np.sqrt(2)  # Eq.7
     x2 = (rri_n + rri_plus) / np.sqrt(2)
     sd1 = np.std(x1, ddof=1)
@@ -283,7 +298,7 @@ def _hrv_nonlinear_poincare(rri, out):
     return out
 
 
-def _hrv_nonlinear_poincare_hra(rri, out):
+def _hrv_nonlinear_poincare_hra(rri, rri_time=None, rri_missing=False, out={}):
     """Heart Rate Asymmetry Indices.
 
     - Asymmetry of Poincaré plot (or termed as heart rate asymmetry, HRA) - Yan (2017)
@@ -294,6 +309,12 @@ def _hrv_nonlinear_poincare_hra(rri, out):
     N = len(rri) - 1
     x = rri[:-1]  # rri_n, x-axis
     y = rri[1:]  # rri_plus, y-axis
+    
+    if rri_missing:
+        # Only include successive differences
+        x = x[_intervals_successive(rri, intervals_time=rri_time)]
+        y = y[_intervals_successive(rri, intervals_time=rri_time)]
+        N = len(x)
 
     diff = y - x
     decelerate_indices = np.where(diff > 0)[0]  # set of points above IL where y > x
@@ -373,17 +394,22 @@ def _hrv_nonlinear_poincare_hra(rri, out):
     return out
 
 
-def _hrv_nonlinear_fragmentation(rri, out):
+def _hrv_nonlinear_fragmentation(rri, rri_time=None, rri_missing=False, out={}):
     """Heart Rate Fragmentation Indices - Costa (2017)
 
     The more fragmented a time series is, the higher the PIP, IALS, PSS, and PAS indices will be.
     """
 
     diff_rri = np.diff(rri)
+    if rri_missing:
+        # Only include successive differences
+        diff_rri = diff_rri[_intervals_successive(rri, intervals_time=rri_time)]
+    
     zerocrossings = signal_zerocrossings(diff_rri)
 
     # Percentage of inflection points (PIP)
-    out["PIP"] = len(zerocrossings) / len(rri)
+    N = len(diff_rri) + 1
+    out["PIP"] = len(zerocrossings) / N
 
     # Inverse of the average length of the acceleration/deceleration segments (IALS)
     accelerations = np.where(diff_rri > 0)[0]
@@ -469,9 +495,9 @@ def _hrv_dfa(rri, out, n_windows="default", **kwargs):
 # =============================================================================
 # Plot
 # =============================================================================
-def _hrv_nonlinear_show(rri, out, ax=None, ax_marg_x=None, ax_marg_y=None):
+def _hrv_nonlinear_show(rri, rri_time=None, rri_missing=False, out={}, ax=None, ax_marg_x=None, ax_marg_y=None):
 
-    mean_heart_period = np.mean(rri)
+    mean_heart_period = np.nanmean(rri)
     sd1 = out["SD1"]
     sd2 = out["SD2"]
     if isinstance(sd1, pd.Series):
@@ -482,6 +508,11 @@ def _hrv_nonlinear_show(rri, out, ax=None, ax_marg_x=None, ax_marg_y=None):
     # Poincare values
     ax1 = rri[:-1]
     ax2 = rri[1:]
+    
+    if rri_missing:
+        # Only include successive differences
+        ax1 = ax1[_intervals_successive(rri, intervals_time=rri_time)]
+        ax2 = ax2[_intervals_successive(rri, intervals_time=rri_time)]
 
     # Set grid boundaries
     ax1_lim = (max(ax1) - min(ax1)) / 10

--- a/neurokit2/hrv/hrv_nonlinear.py
+++ b/neurokit2/hrv/hrv_nonlinear.py
@@ -206,7 +206,7 @@ def hrv_nonlinear(peaks, sampling_rate=1000, show=False, **kwargs):
     """
     # Sanitize input
     # If given peaks, compute R-R intervals (also referred to as NN) in milliseconds
-    rri, _ = _hrv_format_input(peaks, sampling_rate=sampling_rate)
+    rri, _, _ = _hrv_format_input(peaks, sampling_rate=sampling_rate)
 
     # Initialize empty container for results
     out = {}

--- a/neurokit2/hrv/hrv_rqa.py
+++ b/neurokit2/hrv/hrv_rqa.py
@@ -85,7 +85,7 @@ def hrv_rqa(
     """
     # Sanitize input
     # If given peaks, compute R-R intervals (also referred to as NN) in milliseconds
-    rri, _ = _hrv_format_input(peaks, sampling_rate=sampling_rate)
+    rri, _, _ = _hrv_format_input(peaks, sampling_rate=sampling_rate)
 
     # Linear detrend (Zimatore, 2021)
     rri = signal_detrend(rri, method="polynomial", order=1)

--- a/neurokit2/hrv/hrv_rsa.py
+++ b/neurokit2/hrv/hrv_rsa.py
@@ -368,7 +368,7 @@ def _hrv_rsa_gates(
     # Re-sample at 4 Hz
     desired_sampling_rate = 4
 
-    rri, sampling_rate = intervals_process(
+    rri, rri_time, sampling_rate = intervals_process(
         rri, intervals_time=rri_time, interpolate=True, interpolation_rate=desired_sampling_rate
     )
 

--- a/neurokit2/hrv/hrv_rsa.py
+++ b/neurokit2/hrv/hrv_rsa.py
@@ -362,8 +362,8 @@ def _hrv_rsa_gates(
     min_frequency = 0.12
     max_frequency = 0.40
 
-    # Retrived IBI and interpolate it
-    rri, rri_time = _hrv_get_rri(rpeaks, sampling_rate=sampling_rate)
+    # Retrieve IBI and interpolate it
+    rri, rri_time, _ = _hrv_get_rri(rpeaks, sampling_rate=sampling_rate)
 
     # Re-sample at 4 Hz
     desired_sampling_rate = 4

--- a/neurokit2/hrv/hrv_time.py
+++ b/neurokit2/hrv/hrv_time.py
@@ -208,30 +208,38 @@ def _hrv_time_show(rri, **kwargs):
     return fig
 
 
-def _sdann(rri, window=1):
+def _sdann(rri, rri_time=None, window=1):
 
     window_size = window * 60 * 1000  # Convert window in min to ms
-    n_windows = int(np.round(np.cumsum(rri)[-1] / window_size))
+    if rri_time is None:
+        # Compute the timestamps of the R-R intervals in seconds
+        rri_time = np.nancumsum(rri / 1000)
+    # Convert timestamps to milliseconds and ensure first timestamp is equal to first interval
+    rri_cumsum = (rri_time - rri_time[0])*1000 + rri[0]
+    n_windows = int(np.round(rri_cumsum[-1] / window_size))
     if n_windows < 3:
         return np.nan
-    rri_cumsum = np.cumsum(rri)
     avg_rri = []
     for i in range(n_windows):
         start = i * window_size
         start_idx = np.where(rri_cumsum >= start)[0][0]
         end_idx = np.where(rri_cumsum < start + window_size)[0][-1]
-        avg_rri.append(np.mean(rri[start_idx:end_idx]))
+        avg_rri.append(np.nanmean(rri[start_idx:end_idx]))
     sdann = np.nanstd(avg_rri, ddof=1)
     return sdann
 
 
-def _sdnni(rri, window=1):
+def _sdnni(rri, rri_time=None, window=1):
 
     window_size = window * 60 * 1000  # Convert window in min to ms
-    n_windows = int(np.round(np.cumsum(rri)[-1] / window_size))
+    if rri_time is None:
+        # Compute the timestamps of the R-R intervals in seconds
+        rri_time = np.nancumsum(rri / 1000)
+    # Convert timestamps to milliseconds and ensure first timestamp is equal to first interval
+    rri_cumsum = (rri_time - rri_time[0])*1000 + rri[0]
+    n_windows = int(np.round(rri_cumsum[-1] / window_size))
     if n_windows < 3:
         return np.nan
-    rri_cumsum = np.cumsum(rri)
     sdnn_ = []
     for i in range(n_windows):
         start = i * window_size

--- a/neurokit2/hrv/hrv_time.py
+++ b/neurokit2/hrv/hrv_time.py
@@ -135,7 +135,7 @@ def hrv_time(peaks, sampling_rate=1000, show=False, **kwargs):
     """
     # Sanitize input
     # If given peaks, compute R-R intervals (also referred to as NN) in milliseconds
-    rri, _ = _hrv_format_input(peaks, sampling_rate=sampling_rate)
+    rri, _, _ = _hrv_format_input(peaks, sampling_rate=sampling_rate)
 
     diff_rri = np.diff(rri)
 

--- a/neurokit2/hrv/hrv_utils.py
+++ b/neurokit2/hrv/hrv_utils.py
@@ -9,7 +9,7 @@ from .intervals_utils import _intervals_sanitize
 
 def _hrv_get_rri(peaks=None, sampling_rate=1000):
     if peaks is None:
-        return None, None
+        return None, None, None
     # Compute R-R intervals (also referred to as NN) in milliseconds
     rri = np.diff(peaks) / sampling_rate * 1000
     rri, rri_time, rri_missing = _intervals_sanitize(rri)

--- a/neurokit2/hrv/intervals_process.py
+++ b/neurokit2/hrv/intervals_process.py
@@ -81,7 +81,7 @@ def intervals_process(
 
     """
     # Sanitize input
-    intervals, intervals_time = _intervals_sanitize(intervals, intervals_time=intervals_time)
+    intervals, intervals_time, _ = _intervals_sanitize(intervals, intervals_time=intervals_time)
 
     if interpolate is False:
         interpolation_rate = None

--- a/neurokit2/hrv/intervals_process.py
+++ b/neurokit2/hrv/intervals_process.py
@@ -108,6 +108,7 @@ def intervals_process(
         )
 
         intervals = signal_interpolate(intervals_time, intervals, x_new=x_new, **kwargs)
+        intervals_time = x_new
     else:
         # check if intervals appear to be already interpolated
         if _intervals_time_uniform(intervals_time):

--- a/neurokit2/hrv/intervals_process.py
+++ b/neurokit2/hrv/intervals_process.py
@@ -116,4 +116,4 @@ def intervals_process(
 
     if detrend is not None:
         intervals = signal_detrend(intervals, method=detrend)
-    return intervals, interpolation_rate
+    return intervals, intervals_time, interpolation_rate

--- a/neurokit2/hrv/intervals_to_peaks.py
+++ b/neurokit2/hrv/intervals_to_peaks.py
@@ -50,7 +50,8 @@ def intervals_to_peaks(intervals, intervals_time=None, sampling_rate=1000):
         non_successive_indices = np.arange(1, len(intervals_time))[
             np.invert(_intervals_successive(intervals, intervals_time))
         ]
-
+    else:
+        non_successive_indices = np.array([])
     # The number of peaks should be the number of intervals
     # plus one extra at the beginning of each group of successive intervals
     # (with no missing data there should be N_intervals + 1 peaks)

--- a/neurokit2/hrv/intervals_to_peaks.py
+++ b/neurokit2/hrv/intervals_to_peaks.py
@@ -41,14 +41,15 @@ def intervals_to_peaks(intervals, intervals_time=None, sampling_rate=1000):
     if intervals is None:
         return None
 
-    intervals, intervals_time = _intervals_sanitize(
+    intervals, intervals_time, intervals_missing = _intervals_sanitize(
         intervals, intervals_time=intervals_time, remove_missing=True
     )
-
-    # Check for non successive intervals in case of missing data
-    non_successive_indices = np.arange(1, len(intervals_time))[
-        np.invert(_intervals_successive(intervals, intervals_time))
-    ]
+    
+    if intervals_missing:
+        # Check for non successive intervals in case of missing data
+        non_successive_indices = np.arange(1, len(intervals_time))[
+            np.invert(_intervals_successive(intervals, intervals_time))
+        ]
 
     # The number of peaks should be the number of intervals
     # plus one extra at the beginning of each group of successive intervals

--- a/neurokit2/hrv/intervals_to_peaks.py
+++ b/neurokit2/hrv/intervals_to_peaks.py
@@ -51,7 +51,7 @@ def intervals_to_peaks(intervals, intervals_time=None, sampling_rate=1000):
             np.invert(_intervals_successive(intervals, intervals_time))
         ]
     else:
-        non_successive_indices = np.array([])
+        non_successive_indices = np.array([]).astype(int)
     # The number of peaks should be the number of intervals
     # plus one extra at the beginning of each group of successive intervals
     # (with no missing data there should be N_intervals + 1 peaks)

--- a/neurokit2/hrv/intervals_utils.py
+++ b/neurokit2/hrv/intervals_utils.py
@@ -106,6 +106,8 @@ def _intervals_sanitize(intervals, intervals_time=None, remove_missing=True):
         Sanitized intervals, in milliseconds.
     intervals_time : array
         Sanitized timestamps corresponding to intervals, in seconds.
+    intervals_missing : bool
+        Whether there were missing intervals detected.
 
     Examples
     ---------
@@ -113,7 +115,7 @@ def _intervals_sanitize(intervals, intervals_time=None, remove_missing=True):
 
       import neurokit2 as nk
       ibi = [500, 400, 700, 500, 300, 800, 500]
-      ibi, ibi_time = intervals_sanitize(ibi)
+      ibi, ibi_time, intervals_missing = intervals_sanitize(ibi)
 
     """
     if intervals is None:
@@ -122,8 +124,12 @@ def _intervals_sanitize(intervals, intervals_time=None, remove_missing=True):
         # Ensure that input is numpy array
         intervals = np.array(intervals)
     if intervals_time is None:
+        # Impute intervals with median in case of missing values to calculate timestamps
+        imputed_intervals = np.where(np.isnan(intervals), 
+                                     np.nanmedian(intervals, axis=0), 
+                                     intervals)
         # Compute the timestamps of the intervals in seconds
-        intervals_time = np.nancumsum(intervals / 1000)
+        intervals_time = np.nancumsum(imputed_intervals / 1000)
     else:
         # Ensure that input is numpy array
         intervals_time = np.array(intervals_time)
@@ -146,12 +152,26 @@ def _intervals_sanitize(intervals, intervals_time=None, remove_missing=True):
                 ):
                     # Assume timestamps were passed in milliseconds and convert to seconds
                     intervals_time = intervals_time / 1000
+    
+    intervals_missing = _intervals_missing(intervals, intervals_time)
 
     if remove_missing:
         # Remove NaN R-R intervals, if any
         intervals_time = intervals_time[np.isfinite(intervals)]
         intervals = intervals[np.isfinite(intervals)]
-    return intervals, intervals_time
+    return intervals, intervals_time, intervals_missing
+
+
+def _intervals_missing(intervals, intervals_time=None, min_n_true=2):
+    if len(intervals[np.isfinite(intervals)]) < len(intervals):
+        return True
+    elif intervals_time is not None:
+        successive_intervals = _intervals_successive(intervals, intervals_time=intervals_time, min_n_true=min_n_true)
+        if np.all(successive_intervals) is False:
+            # Check whether intervals appear to be interpolated
+            if not _intervals_time_uniform(intervals_time):
+                return True
+    return False
 
 
 def _intervals_time_to_sampling_rate(intervals_time, central_measure="mean"):

--- a/neurokit2/hrv/intervals_utils.py
+++ b/neurokit2/hrv/intervals_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 import scipy
 
 
-def _intervals_successive(intervals, intervals_time=None, thresh_unequal=10, n_diff=1):
+def _intervals_successive(intervals, intervals_time=None, thresh_unequal=10, n_diff=1, min_n_true=0):
     """Identify successive intervals.
 
     Identification of intervals that are consecutive
@@ -14,14 +14,15 @@ def _intervals_successive(intervals, intervals_time=None, thresh_unequal=10, n_d
     intervals : list or ndarray
         Intervals, e.g. breath-to-breath (BBI) or rpeak-to-rpeak (RRI)
     intervals_time : list or ndarray, optional
-        Time points corresponding to intervals, in seconds.
+        Time points corresponding to intervals, in seconds. Defaults to None,
+        in which case the cumulative sum of the intervals is used.
     thresh_unequal : int or float, optional
         Threshold at which the difference between time points is considered to
-        be unequal to the interval, in milliseconds.
+        be unequal to the interval, in milliseconds. Defaults to 10.
     n_diff: int, optional
         The number of times values are differenced.
         Can be used to check which values are valid for the n-th difference
-        assuming successive intervals.
+        assuming successive intervals. Defaults to 1.
 
     Returns
     ----------

--- a/neurokit2/hrv/intervals_utils.py
+++ b/neurokit2/hrv/intervals_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 import scipy
 
 
-def _intervals_successive(intervals, intervals_time=None, thresh_unequal=2, n_diff=1):
+def _intervals_successive(intervals, intervals_time=None, thresh_unequal=10, n_diff=1):
     """Identify successive intervals.
 
     Identification of intervals that are consecutive

--- a/tests/tests_hrv.py
+++ b/tests/tests_hrv.py
@@ -84,11 +84,11 @@ def test_hrv_detrended_rri(detrend):
     rri = np.diff(peaks).astype(float)
     rri_time = peaks[1:] / 1000
 
-    rri_processed, _ = nk.intervals_process(
+    rri_processed, rri_processed_time, _ = nk.intervals_process(
         rri, intervals_time=rri_time, interpolate=False, interpolation_rate=None, detrend=detrend
     )
 
-    ecg_hrv = nk.hrv({"RRI": rri_processed, "RRI_Time": rri_time})
+    ecg_hrv = nk.hrv({"RRI": rri_processed, "RRI_Time": rri_processed_time})
 
     assert np.isclose(ecg_hrv["HRV_RMSSD"].values[0], np.sqrt(np.mean(np.square(np.diff(rri_processed)))), atol=0.1)
 
@@ -106,15 +106,10 @@ def test_hrv_interpolated_rri(interpolation_rate):
     if interpolation_rate=="from_mean_rri":
         interpolation_rate = 1000/np.mean(rri)
 
-    rri_processed, _ = nk.intervals_process(
+    rri_processed, rri_processed_time, _ = nk.intervals_process(
         rri, intervals_time=rri_time, interpolate=True, interpolation_rate=interpolation_rate
     )
 
-    rri_processed_time = np.arange(
-        start=rri_time[0],
-        stop=rri_time[-1] + 1 / interpolation_rate,
-        step=1 / interpolation_rate,
-    )
 
     ecg_hrv = nk.hrv({"RRI": rri_processed, "RRI_Time": rri_processed_time})
 

--- a/tests/tests_hrv.py
+++ b/tests/tests_hrv.py
@@ -65,15 +65,15 @@ def test_rri_input_hrv():
     _, peaks = nk.ecg_process(ecg, sampling_rate=1000)
     peaks = peaks["ECG_R_Peaks"]
     rri = np.diff(peaks).astype(float)
-    rri_time = peaks[1:]/1000
+    rri_time = peaks[1:] / 1000
 
     rri[3:5] = [np.nan, np.nan]
 
     ecg_hrv = nk.hrv({"RRI": rri, "RRI_Time": rri_time})
 
     assert np.isclose(ecg_hrv["HRV_RMSSD"].values[0], 3.526, atol=0.2)
-    
-    
+
+
 def test_hrv_detrended_rri():
 
     ecg = nk.ecg_simulate(duration=120, sampling_rate=1000, heart_rate=110, random_state=42)
@@ -81,17 +81,15 @@ def test_hrv_detrended_rri():
     _, peaks = nk.ecg_process(ecg, sampling_rate=1000)
     peaks = peaks["ECG_R_Peaks"]
     rri = np.diff(peaks).astype(float)
-    rri_time = peaks[1:]/1000
-    
-    rri_processed, _ = nk.intervals_process(rri,
-                                            intervals_time=rri_time,
-                                            interpolate=False,
-                                            interpolation_rate=None,
-                                            detrend="tarvainen2002")
+    rri_time = peaks[1:] / 1000
+
+    rri_processed, _ = nk.intervals_process(
+        rri, intervals_time=rri_time, interpolate=False, interpolation_rate=None, detrend="tarvainen2002"
+    )
 
     ecg_hrv = nk.hrv({"RRI": rri_processed, "RRI_Time": rri_time})
 
-    assert np.isclose(ecg_hrv["HRV_RMSSD"].values[0], np.sqrt(np.mean(np.square(rri_processed))), atol=0.1)
+    assert np.isclose(ecg_hrv["HRV_RMSSD"].values[0], np.sqrt(np.mean(np.square(np.diff(rri_processed)))), atol=0.1)
 
 
 def test_hrv_rsa():
@@ -110,9 +108,7 @@ def test_hrv_rsa():
         "RSA_Gates_SD",
     ]
 
-    rsa_features = nk.hrv_rsa(
-        ecg_signals, rsp_signals, rpeaks=info, sampling_rate=100, continuous=False
-    )
+    rsa_features = nk.hrv_rsa(ecg_signals, rsp_signals, rpeaks=info, sampling_rate=100, continuous=False)
 
     assert all(key in rsa_feature_columns for key in rsa_features.keys())
 

--- a/tests/tests_hrv.py
+++ b/tests/tests_hrv.py
@@ -72,6 +72,26 @@ def test_rri_input_hrv():
     ecg_hrv = nk.hrv({"RRI": rri, "RRI_Time": rri_time})
 
     assert np.isclose(ecg_hrv["HRV_RMSSD"].values[0], 3.526, atol=0.2)
+    
+    
+def test_hrv_detrended_rri():
+
+    ecg = nk.ecg_simulate(duration=120, sampling_rate=1000, heart_rate=110, random_state=42)
+
+    _, peaks = nk.ecg_process(ecg, sampling_rate=1000)
+    peaks = peaks["ECG_R_Peaks"]
+    rri = np.diff(peaks).astype(float)
+    rri_time = peaks[1:]/1000
+    
+    rri_processed, _ = nk.intervals_process(rri,
+                                            intervals_time=rri_time,
+                                            interpolate=False,
+                                            interpolation_rate=None,
+                                            detrend="tarvainen2002")
+
+    ecg_hrv = nk.hrv({"RRI": rri_processed, "RRI_Time": rri_time})
+
+    assert np.isclose(ecg_hrv["HRV_RMSSD"].values[0], np.sqrt(np.mean(np.square(rri_processed))), atol=0.1)
 
 
 def test_hrv_rsa():

--- a/tests/tests_hrv.py
+++ b/tests/tests_hrv.py
@@ -93,7 +93,7 @@ def test_hrv_detrended_rri(detrend):
     assert np.isclose(ecg_hrv["HRV_RMSSD"].values[0], np.sqrt(np.mean(np.square(np.diff(rri_processed)))), atol=0.1)
 
 
-@pytest.mark.parametrize("interpolation_rate", ["from_mean_rri", 1, 4, 1000])
+@pytest.mark.parametrize("interpolation_rate", ["from_mean_rri", 1, 4, 100])
 def test_hrv_interpolated_rri(interpolation_rate):
 
     ecg = nk.ecg_simulate(duration=120, sampling_rate=1000, heart_rate=110, random_state=42)

--- a/tests/tests_hrv.py
+++ b/tests/tests_hrv.py
@@ -74,7 +74,7 @@ def test_rri_input_hrv():
     assert np.isclose(ecg_hrv["HRV_RMSSD"].values[0], 3.526, atol=0.2)
 
 
-@pytest.mark.parametrize("detrend", ["tarvainen2002", "polynomial", "tarvainen2002", "loess", "locreg"])
+@pytest.mark.parametrize("detrend", ["tarvainen2002", "polynomial", "tarvainen2002", "loess"])
 def test_hrv_detrended_rri(detrend):
 
     ecg = nk.ecg_simulate(duration=120, sampling_rate=1000, heart_rate=110, random_state=42)

--- a/tests/tests_hrv.py
+++ b/tests/tests_hrv.py
@@ -102,14 +102,21 @@ def test_hrv_interpolated_rri(interpolation_rate):
     peaks = peaks["ECG_R_Peaks"]
     rri = np.diff(peaks).astype(float)
     rri_time = peaks[1:] / 1000
-    
+
     if interpolation_rate=="from_mean_rri":
         interpolation_rate = 1000/np.mean(rri)
+
     rri_processed, _ = nk.intervals_process(
         rri, intervals_time=rri_time, interpolate=True, interpolation_rate=interpolation_rate
     )
 
-    ecg_hrv = nk.hrv({"RRI": rri_processed, "RRI_Time": rri_time})
+    rri_processed_time = np.arange(
+        start=rri_time[0],
+        stop=rri_time[-1] + 1 / interpolation_rate,
+        step=1 / interpolation_rate,
+    )
+
+    ecg_hrv = nk.hrv({"RRI": rri_processed, "RRI_Time": rri_processed_time})
 
     assert np.isclose(ecg_hrv["HRV_RMSSD"].values[0], np.sqrt(np.mean(np.square(np.diff(rri_processed)))), atol=0.1)
 

--- a/tests/tests_hrv.py
+++ b/tests/tests_hrv.py
@@ -106,7 +106,7 @@ def test_hrv_interpolated_rri(interpolation_rate):
     if interpolation_rate=="from_mean_rri":
         interpolation_rate = 1000/np.mean(rri)
     rri_processed, _ = nk.intervals_process(
-        rri, intervals_time=rri_time, interpolate=False, interpolation_rate=interpolation_rate
+        rri, intervals_time=rri_time, interpolate=True, interpolation_rate=interpolation_rate
     )
 
     ecg_hrv = nk.hrv({"RRI": rri_processed, "RRI_Time": rri_time})


### PR DESCRIPTION
# Description

This PR aims at adding the ability to perform HRV analysis in the case of missing interbeat intervals. See also https://github.com/neuropsychology/NeuroKit/issues/541

# Proposed Changes

I changed the `hrv_time()` and `hrv_nonlinear()` functions so that for some features, differences between intervals that are not actually successive are removed and the timestamps of the intervals are taken into account. 

# Checklist
(Maybe this checklist should be updated to remove the code checks & News.rst points? https://github.com/neuropsychology/NeuroKit/issues/692#issuecomment-1211437961)
- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)