### PR TITLE
[Fix] Detection of missing interbeat intervals

### DIFF
--- a/neurokit2/hrv/intervals_utils.py
+++ b/neurokit2/hrv/intervals_utils.py
@@ -165,7 +165,7 @@ def _intervals_missing(intervals, intervals_time=None):
         return True
     elif intervals_time is not None:
         successive_intervals = _intervals_successive(intervals, intervals_time=intervals_time)
-        if np.all(successive_intervals) is False:
+        if not np.all(successive_intervals):
             # Check whether intervals appear to be interpolated
             if not _intervals_time_uniform(intervals_time):
                 return True

--- a/neurokit2/hrv/intervals_utils.py
+++ b/neurokit2/hrv/intervals_utils.py
@@ -165,7 +165,7 @@ def _intervals_missing(intervals, intervals_time=None):
         return True
     elif intervals_time is not None:
         successive_intervals = _intervals_successive(intervals, intervals_time=intervals_time)
-        if not np.all(successive_intervals):
+        if not np.all(successive_intervals) and np.any(successive_intervals):
             # Check whether intervals appear to be interpolated
             if not _intervals_time_uniform(intervals_time):
                 return True

--- a/tests/tests_hrv.py
+++ b/tests/tests_hrv.py
@@ -103,18 +103,53 @@ def test_hrv_interpolated_rri(interpolation_rate):
     rri = np.diff(peaks).astype(float)
     rri_time = peaks[1:] / 1000
 
-    if interpolation_rate=="from_mean_rri":
-        interpolation_rate = 1000/np.mean(rri)
+    if interpolation_rate == "from_mean_rri":
+        interpolation_rate = 1000 / np.mean(rri)
 
     rri_processed, rri_processed_time, _ = nk.intervals_process(
         rri, intervals_time=rri_time, interpolate=True, interpolation_rate=interpolation_rate
     )
 
-
     ecg_hrv = nk.hrv({"RRI": rri_processed, "RRI_Time": rri_processed_time})
 
     assert np.isclose(ecg_hrv["HRV_RMSSD"].values[0], np.sqrt(np.mean(np.square(np.diff(rri_processed)))), atol=0.1)
 
+
+def test_hrv_missing():
+    random_state = 42
+    # Download data
+    data = nk.data("bio_resting_5min_100hz")
+    sampling_rate = 100
+    ecg = data["ECG"]
+
+    _, peaks = nk.ecg_process(ecg, sampling_rate=sampling_rate)
+    peaks = peaks["ECG_R_Peaks"]
+
+    rri = np.diff(peaks / sampling_rate).astype(float) * 1000
+    rri_time = peaks[1:] / sampling_rate
+
+    # remove some intervals and their corresponding timestamps
+    np.random.seed(random_state)
+    missing = np.random.randint(0, len(rri), size=int(len(rri) / 5))
+    rri_missing = rri[np.array([i for i in range(len(rri)) if i not in missing])]
+    rri_time_missing = rri_time[np.array([i for i in range(len(rri_time)) if i not in missing])]
+
+    orig_hrv = nk.hrv_time(peaks, sampling_rate=sampling_rate)
+    miss_only_rri_hrv = nk.hrv_time({"RRI": rri_missing})
+    # by providing the timestamps corresponding to each interval
+    # we should be able to better estimate the original RMSSD
+    # before some intervals were removed
+    # (at least for this example signal)
+    miss_rri_time_hrv = nk.hrv_time({"RRI": rri_missing, "RRI_Time": rri_time_missing})
+
+    abs_diff_only_rri = np.mean(
+        np.abs(np.diff([orig_hrv["HRV_RMSSD"].values[0], miss_only_rri_hrv["HRV_RMSSD"].values[0]]))
+    )
+    abs_diff_rri_time = np.mean(
+        np.abs(np.diff([orig_hrv["HRV_RMSSD"].values[0], miss_rri_time_hrv["HRV_RMSSD"].values[0]]))
+    )
+
+    assert abs_diff_only_rri > abs_diff_rri_time
 
 
 def test_hrv_rsa():

--- a/tests/tests_hrv.py
+++ b/tests/tests_hrv.py
@@ -74,7 +74,7 @@ def test_rri_input_hrv():
     assert np.isclose(ecg_hrv["HRV_RMSSD"].values[0], 3.526, atol=0.2)
 
 
-@pytest.mark.parametrize("detrend", ["tarvainen2002", "polynomial", "tarvainen2002", "loess"])
+@pytest.mark.parametrize("detrend", ["polynomial", "loess"])
 def test_hrv_detrended_rri(detrend):
 
     ecg = nk.ecg_simulate(duration=120, sampling_rate=1000, heart_rate=110, random_state=42)


### PR DESCRIPTION
# Description

This PR aims to fix a mistake I made in https://github.com/neuropsychology/NeuroKit/pull/720 that prevented the detection of missing data with the timestamps of interbeat intervals (sorry I just noticed)

# Proposed Changes

I changed the `_intervals_missing()` function so that it returns `True` if the following 3 conditions are satisfied:
1. At least one of the interbeat intervals **doesn't** correspond to the difference between the timestamps provided 
2. At least one of the interbeat intervals **does** correspond to the difference between the timestamps provided 
3. The intervals are not detected to be interpolated

I also added a test `test_hrv_missing()` to confirm that providing the timestamps corresponding to the interbeat intervals improves the estimation of RMSSD with missing data.

# Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.