### PR TITLE
Added creative commons license to documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ def find_author():
 
 project = "NeuroKit2"
 copyright = f"2020–{datetime.datetime.now().year}"
-author = '<a href="https://dominiquemakowski.github.io/">Dominique Makowski</a> and the <a href="https://github.com/neuropsychology/NeuroKit/blob/master/AUTHORS.rst">Team</a>'
+author = '<a href="https://dominiquemakowski.github.io/">Dominique Makowski</a> and the <a href="https://github.com/neuropsychology/NeuroKit/blob/master/AUTHORS.rst">Team</a>. This documentation is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a> license.'
 
 # The short X.Y version.
 def find_version():


### PR DESCRIPTION
# Description

This PR aims to add a creative commons license to documentation (as discussed in #769 ).

# Proposed Changes

I changed the `conf.py` file by appending some text to the 'author' field. The text states the license for the documentation.

# Further Details

The current commit uses the [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) license, which is the license commonly used in open access publications. The license does require the user to attribute the original source. It allows the authors to retain the copyright.

An alternative, more permissive license is the [CC0](https://creativecommons.org/share-your-work/public-domain/cc0/) license, which places work "as completely as possible in the public domain". This would remove the need for users to attribute the original documentation, and would also mean that the authors opt out of copyright.

The advice in the 'Before licensing' section of [this webpage](https://creativecommons.org/about/cclicenses/) is helpful. Briefly, it's worth noting that "only the copyright holder or someone with express permission from the copyright holder can apply a CC license or CC0 to a copyrighted work."

# Checklist

_I've tried this on a template sphinx documentation build and it seemed to build ok there. I haven't incorporated it into a build on the full Neurokit documentation._

- [X] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [X] My PR is targetted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)