### PR TITLE
[Fix] invalid indices in ecg_delineate

### DIFF
--- a/neurokit2/ecg/ecg_delineate.py
+++ b/neurokit2/ecg/ecg_delineate.py
@@ -164,6 +164,11 @@ def ecg_delineate(
             "NeuroKit error: ecg_delineate(): 'method' should be one of 'peak'," "'cwt' or 'dwt'."
         )
 
+    # Ensure that all indices are not larger than ECG signal indices
+    for _, value in waves.items():
+        if value[-1] >= len(ecg_cleaned):
+            value[-1] = np.nan
+
     # Remove NaN in Peaks, Onsets, and Offsets
     waves_noNA = waves.copy()
     for feature in waves_noNA.keys():
@@ -946,11 +951,6 @@ def _ecg_delineator_peak(ecg, rpeaks=None, sampling_rate=1000):
         "ECG_P_Onsets": P_onsets,
         "ECG_T_Offsets": T_offsets,
     }
-
-    # Ensure that all indices are not larger than ECG signal indices
-    for _, value in info.items():
-        if value[-1] >= len(ecg):
-            value[-1] = np.nan
 
     # Return info dictionary
     return info

--- a/neurokit2/ecg/ecg_segment.py
+++ b/neurokit2/ecg/ecg_segment.py
@@ -58,6 +58,12 @@ def ecg_segment(ecg_cleaned, rpeaks=None, sampling_rate=1000, show=False):
         epochs_start=epochs_start,
         epochs_end=epochs_end,
     )
+    
+    # remove appended zeros from last heartbeat
+    last_heartbeat_key = str(np.max(np.array(list(heartbeats.keys()), dtype=int)))
+    heartbeats[last_heartbeat_key] = heartbeats[last_heartbeat_key][
+        heartbeats[last_heartbeat_key]["Index"] < len(ecg_cleaned)
+    ]
 
     if show:
         heartbeats_plot = epochs_to_df(heartbeats)

--- a/neurokit2/ecg/ecg_segment.py
+++ b/neurokit2/ecg/ecg_segment.py
@@ -59,11 +59,11 @@ def ecg_segment(ecg_cleaned, rpeaks=None, sampling_rate=1000, show=False):
         epochs_end=epochs_end,
     )
     
-    # remove appended zeros from last heartbeat
+    # pad last heartbeat with nan so that segments are equal length
     last_heartbeat_key = str(np.max(np.array(list(heartbeats.keys()), dtype=int)))
-    heartbeats[last_heartbeat_key] = heartbeats[last_heartbeat_key][
+    heartbeats[last_heartbeat_key][
         heartbeats[last_heartbeat_key]["Index"] < len(ecg_cleaned)
-    ]
+    ]["Signal"] = np.nan
 
     if show:
         heartbeats_plot = epochs_to_df(heartbeats)

--- a/neurokit2/ecg/ecg_segment.py
+++ b/neurokit2/ecg/ecg_segment.py
@@ -61,9 +61,8 @@ def ecg_segment(ecg_cleaned, rpeaks=None, sampling_rate=1000, show=False):
     
     # pad last heartbeat with nan so that segments are equal length
     last_heartbeat_key = str(np.max(np.array(list(heartbeats.keys()), dtype=int)))
-    heartbeats[last_heartbeat_key][
-        heartbeats[last_heartbeat_key]["Index"] < len(ecg_cleaned)
-    ]["Signal"] = np.nan
+    after_last_index = heartbeats[last_heartbeat_key]["Index"] < len(ecg_cleaned)
+    heartbeats[last_heartbeat_key].loc[after_last_index, "Signal"] = np.nan
 
     if show:
         heartbeats_plot = epochs_to_df(heartbeats)


### PR DESCRIPTION
# Description

This prevents indices larger than the ECG signal indices from being returned by `ecg_delineate()`. See https://github.com/neuropsychology/NeuroKit/issues/772

# Proposed Changes

I changed `ecg_delineate()` so that regardless of which delineation method is used, the output is postprocessed such that any indices that are larger than the ECG signal indices are removed (originally this postprocessing was only done in `_ecg_delineator_peak()`.

I also changed `ecg_segment()` so that the final heartbeat segment only contains points from the original ECG signal (not zeros appended at the end), since that caused invalid indices to be detected within `ecg_delineate()`. But I can revert this change or make it an optional argument, as invalid indices will be removed in `ecg_delineate()` anyway.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).