### PR TITLE
[Fix] sanitize RSP extrema found by scipy method

### DIFF
--- a/neurokit2/rsp/rsp_amplitude.py
+++ b/neurokit2/rsp/rsp_amplitude.py
@@ -78,7 +78,7 @@ def rsp_amplitude(
     # Format input.
     peaks, troughs = _rsp_fixpeaks_retrieve(peaks, troughs)
 
-    # To consistenty calculate amplitude, peaks and troughs must have the same
+    # To consistently calculate amplitude, peaks and troughs must have the same
     # number of elements, and the first trough must precede the first peak.
     if (peaks.size != troughs.size) or (peaks[0] <= troughs[0]):
         raise TypeError(

--- a/neurokit2/rsp/rsp_findpeaks.py
+++ b/neurokit2/rsp/rsp_findpeaks.py
@@ -141,6 +141,12 @@ def _rsp_findpeaks_scipy(rsp_cleaned, sampling_rate, peak_distance=0.8, peak_pro
         -rsp_cleaned, distance=peak_distance, prominence=peak_prominence
     )
 
+    # Combine peaks and troughs and sort them.
+    extrema = np.sort(np.concatenate((peaks, troughs)))
+    # Sanitize.
+    extrema, amplitudes = _rsp_findpeaks_outliers(rsp_cleaned, extrema, amplitude_min=0)
+    peaks, troughs = _rsp_findpeaks_sanitize(extrema, amplitudes)
+
     info = {"RSP_Peaks": peaks, "RSP_Troughs": troughs}
     return info
 


### PR DESCRIPTION
# Description
`rsp_amplitude()` expects there to be the same number of peaks and troughs, so I modified the `scipy` method of finding peaks in a respiration signal so that the output is sanitized such that there are the same number of peaks and troughs.

# Proposed Changes
1. I modified `_rsp_findpeaks_scipy()` to use `_rsp_findpeaks_sanitize()`

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).