### PR TITLE
[Fix] interpolate signal with only one value 

### DIFF
--- a/neurokit2/signal/signal_interpolate.py
+++ b/neurokit2/signal/signal_interpolate.py
@@ -97,6 +97,7 @@ def signal_interpolate(x_values, y_values=None, x_new=None, method="quadratic", 
     if isinstance(x_new, int):
         if len(x_values) == x_new:
             return y_values
+        x_new = np.linspace(x_values[0], x_values[-1], x_new)
     else:
         # if x_values is identical to x_new, no need for interpolation
         if np.all(x_values == x_new):
@@ -120,8 +121,7 @@ def signal_interpolate(x_values, y_values=None, x_new=None, method="quadratic", 
             bounds_error=False,
             fill_value=fill_value,
         )
-    if isinstance(x_new, int):
-        x_new = np.linspace(x_values[0], x_values[-1], x_new)
+
     interpolated = interpolation_function(x_new)
 
     if method == "monotone_cubic" and fill_value != "extrapolate":

--- a/neurokit2/signal/signal_interpolate.py
+++ b/neurokit2/signal/signal_interpolate.py
@@ -101,6 +101,11 @@ def signal_interpolate(x_values, y_values=None, x_new=None, method="quadratic", 
         # if x_values is identical to x_new, no need for interpolation
         if np.all(x_values == x_new):
             return y_values
+
+    # If only one value, return a constant signal
+    if len(x_values) == 1:
+        return np.ones(len(x_new)) * y_values[0]
+
     if method == "monotone_cubic":
         interpolation_function = scipy.interpolate.PchipInterpolator(
             x_values, y_values, extrapolate=True


### PR DESCRIPTION
# Description

Interpolating a single value currently raises an error, causing tests [here](https://github.com/neuropsychology/NeuroKit/pull/785) to fail, and I know this has also previously been an issue https://github.com/neuropsychology/NeuroKit/issues/740

# Proposed Changes

I changed the `signal_interpolate()` function so that it returns a constant signal if only one x value is provided rather than raising an error. 

We could alternatively check the length of the input to `signal_interpolate()` in `rsp_rvt()` where it is currently causing the error. But unless we can think of a situation in which a constant signal is not the desired output given only one x value, I feel like directly modifying `signal_interpolate()` makes more sense than checking the length of the input wherever `signal_interpolate()` is used? 

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).