### PR TITLE
[Fix] Function used in rsp_methods

### DIFF
--- a/neurokit2/ppg/ppg_process.py
+++ b/neurokit2/ppg/ppg_process.py
@@ -110,7 +110,7 @@ def ppg_process(ppg_signal, sampling_rate=1000, method="elgendi", report=None, *
     if report is not None:
         # Generate report containing description and figures of processing
         if ".html" in report:
-            fig = ppg_plot(signals, sampling_rate=sampling_rate)
+            fig = ppg_plot(signals, sampling_rate=sampling_rate, static=False)
         else:
             fig = None
         create_report(file=report, signals=signals, info=methods, fig=fig)

--- a/neurokit2/rsp/rsp_methods.py
+++ b/neurokit2/rsp/rsp_methods.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from ..misc.report import get_kwargs
 from .rsp_clean import rsp_clean
-from .rsp_findpeaks import rsp_findpeaks
+from .rsp_peaks import rsp_peaks
 from .rsp_rvt import rsp_rvt
 
 
@@ -39,14 +39,14 @@ def rsp_methods(
         The method used to find peaks. If ``"default"``,
         will be set to the value of ``"method"``. Defaults to ``"default"``.
         For more information, see the ``"method"`` argument
-        of :func:`.rsp_findpeaks`.
+        of :func:`.rsp_peaks`.
     method_rvt: str
         The method used to compute respiratory volume per time. Defaults to ``"harrison"``.
         For more information, see the ``"method"`` argument
         of :func:`.rsp_rvt`.
     **kwargs
-        Other arguments to be passed to :func:`.rsp_clean` and
-        :func:`.rsp_findpeaks`.
+        Other arguments to be passed to :func:`.rsp_clean`,
+        :func:`.rsp_peaks`, and :func:`.rsp_rvt`.
 
     Returns
     -------
@@ -87,7 +87,7 @@ def rsp_methods(
 
     # Get arguments to be passed to cleaning and peak finding functions
     kwargs_cleaning, report_info = get_kwargs(report_info, rsp_clean)
-    kwargs_peaks, report_info = get_kwargs(report_info, rsp_findpeaks)
+    kwargs_peaks, report_info = get_kwargs(report_info, rsp_peaks)
     kwargs_rvt, report_info = get_kwargs(report_info, rsp_rvt)
 
     # Save keyword arguments in dictionary

--- a/neurokit2/rsp/rsp_process.py
+++ b/neurokit2/rsp/rsp_process.py
@@ -150,7 +150,7 @@ def rsp_process(
     if report is not None:
         # Generate report containing description and figures of processing
         if ".html" in report:
-            fig = rsp_plot(signals, sampling_rate=sampling_rate)
+            fig = rsp_plot(signals, sampling_rate=sampling_rate, static=False)
         else:
             fig = None
         create_report(file=report, signals=signals, info=methods, fig=fig)


### PR DESCRIPTION
# Description
I noticed that `rsp_methods()` uses the default arguments of `rsp_findpeaks()` instead of `rsp_peaks()`. `rsp_peaks()` is the function used in `rsp_process()` so I think we should use that. I also noticed that I left the plots generated in the report static here https://github.com/neuropsychology/NeuroKit/pull/785, so I fixed that. 

# Proposed Changes
1. I changed the `rsp_methods()` function to use `rsp_peaks()`
2. I changed the `rsp_process()` and `ppg_process()` functions to generate reports with interactive plots

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).