### PR TITLE
[Fix] frequency-domain HRV with lombscargle given unevenly spaced data

### DIFF
--- a/neurokit2/hrv/hrv_frequency.py
+++ b/neurokit2/hrv/hrv_frequency.py
@@ -265,12 +265,19 @@ def _hrv_frequency_show(
         __, ax = plt.subplots()
 
     frequency_band = [ulf, vlf, lf, hf, vhf]
+
+    # Compute sampling rate for plot windows
+    if sampling_rate is None:
+        med_sampling_rate = np.median(np.diff(t))
+    else:
+        med_sampling_rate = sampling_rate
+
     for i in range(len(frequency_band)):  # pylint: disable=C0200
         min_frequency = frequency_band[i][0]
         if min_frequency == 0:
             min_frequency = 0.001  # sanitize lowest frequency
 
-        window_length = int((2 / min_frequency) * sampling_rate)
+        window_length = int((2 / min_frequency) * med_sampling_rate)
         if window_length <= len(rri) / 2:
             break
 

--- a/neurokit2/hrv/hrv_frequency.py
+++ b/neurokit2/hrv/hrv_frequency.py
@@ -268,7 +268,7 @@ def _hrv_frequency_show(
 
     # Compute sampling rate for plot windows
     if sampling_rate is None:
-        med_sampling_rate = np.median(np.diff(t))
+        med_sampling_rate = np.median(np.diff(t))  # This is just for visualization purposes (#800)
     else:
         med_sampling_rate = sampling_rate
 

--- a/neurokit2/signal/signal_psd.py
+++ b/neurokit2/signal/signal_psd.py
@@ -137,7 +137,10 @@ def signal_psd(
     # Sanitize min_frequency
     N = len(signal)
     if isinstance(min_frequency, str):
-        min_frequency = (2 * sampling_rate) / (N / 2)  # for high frequency resolution
+        if sampling_rate is None:
+            min_frequency = (2 * np.median(np.diff(t))) / (N / 2)  # for high frequency resolution
+        else:
+            min_frequency = (2 * sampling_rate) / (N / 2)  # for high frequency resolution
 
     # MNE
     if method in ["multitaper", "multitapers", "mne"]:

--- a/neurokit2/signal/signal_psd.py
+++ b/neurokit2/signal/signal_psd.py
@@ -138,6 +138,7 @@ def signal_psd(
     N = len(signal)
     if isinstance(min_frequency, str):
         if sampling_rate is None:
+            # This is to compute min_frequency if both min_frequency and sampling_rate are not provided (#800)
             min_frequency = (2 * np.median(np.diff(t))) / (N / 2)  # for high frequency resolution
         else:
             min_frequency = (2 * sampling_rate) / (N / 2)  # for high frequency resolution


### PR DESCRIPTION
# Description

This PR aims to fix https://github.com/neuropsychology/NeuroKit/issues/799 to plot frequency-domain HRV analysis with the `lombscargle` PSD method given unevenly spaced data 

# Proposed Changes

1. I changed the `_hrv_frequency_show()` and `signal_psd()` so that when `sampling_rate=None`, the sampling rate is estimated using the median difference between timestamps 
_side note: this choice was somewhat arbitrary, I could have also used the mean or mode difference, I thought about adding a function along the lines of `_estimate_sampling_rate(t, method="mode")`, but wasn't sure where to put it_

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).