### PR TITLE
[Docs] add facecolor argument

### DIFF
--- a/docs/readme/README_examples.py
+++ b/docs/readme/README_examples.py
@@ -10,6 +10,7 @@ import neurokit2 as nk
 # Setup matplotlib with Agg to run on server
 matplotlib.use("Agg")
 plt.rcParams["figure.figsize"] = (10, 6.5)
+plt.rcParams["savefig.facecolor"] = "white"
 
 # =============================================================================
 # Quick Example


### PR DESCRIPTION
Adds a white facecolor for all figures in the readme. At the moment, users of the dark github theme can't see text elements around a plot, because the facecolor is transparent. Note that the new figures still have to be generated with the next deployment.