### PR TITLE
[Fix] bishop peaks format

### DIFF
--- a/neurokit2/ppg/ppg_findpeaks.py
+++ b/neurokit2/ppg/ppg_findpeaks.py
@@ -220,8 +220,8 @@ def _ppg_findpeaks_bishop(
     # - column-wise summation
     m_max_sum = np.sum(m_max == False, axis=0)
     m_min_sum = np.sum(m_min == False, axis=0)
-    peaks = np.asarray(np.where(m_max_sum == 0)).astype(int)
-    onsets = np.asarray(np.where(m_min_sum == 0)).astype(int)
+    peaks = np.where(m_max_sum == 0)[0].astype(int)
+    onsets = np.where(m_min_sum == 0)[0].astype(int)
 
     if show:
         _, ax0 = plt.subplots(nrows=1, ncols=1, sharex=True)

--- a/tests/tests_ppg.py
+++ b/tests/tests_ppg.py
@@ -177,7 +177,7 @@ def test_ppg_findpeaks():
 
 @pytest.mark.parametrize(
     "method_cleaning, method_peaks",
-    [("elgendi", "elgendi"), ("nabian2018", "elgendi")],
+    [("elgendi", "elgendi"), ("nabian2018", "elgendi"), ("elgendi", "bishop")],
 )
 def test_ppg_report(tmp_path, method_cleaning, method_peaks):
 

--- a/tests/tests_ppg.py
+++ b/tests/tests_ppg.py
@@ -181,7 +181,7 @@ def test_ppg_findpeaks():
 )
 def test_ppg_report(tmp_path, method_cleaning, method_peaks):
 
-    sampling_rate = 500
+    sampling_rate = 100
 
     ppg = nk.ppg_simulate(
         duration=30,


### PR DESCRIPTION
# Description

This PR aims at fixing an issue with the output format of PPG peaks returned with the bishop method. See also https://github.com/neuropsychology/NeuroKit/issues/831

# Proposed Changes

As suggested by @Ian-Ren (thank you!) I changed the `ppg_findpeaks()` function so that only one dimension is returned. 
I also modified the `test_ppg_report()` function so that the bishop method is tested, to confirm that this change does make the output format correct.

# Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).