### PR TITLE
[Fix] interpolation error when simulating PPG data

### DIFF
--- a/neurokit2/ppg/ppg_simulate.py
+++ b/neurokit2/ppg/ppg_simulate.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.interpolate
 
 from ..misc import check_random_state, check_random_state_children
-from ..signal import signal_distort
+from ..signal import signal_distort, signal_interpolate
 
 
 def ppg_simulate(
@@ -149,9 +149,8 @@ def ppg_simulate(
 
     # Interpolate a continuous signal between the landmarks (i.e., Cartesian
     # coordinates).
-    f = scipy.interpolate.Akima1DInterpolator(x_all, y_all)
     samples = np.arange(int(np.ceil(duration * sampling_rate)))
-    ppg = f(samples)
+    ppg = signal_interpolate(x_values=x_all, y_values=y_all, x_new=samples, method="akima")
     # Remove NAN (values outside interpolation range, i.e., after last sample).
     ppg[np.isnan(ppg)] = np.nanmean(ppg)
 

--- a/neurokit2/ppg/ppg_simulate.py
+++ b/neurokit2/ppg/ppg_simulate.py
@@ -2,7 +2,6 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
-import scipy.interpolate
 
 from ..misc import check_random_state, check_random_state_children
 from ..signal import signal_distort, signal_interpolate

--- a/neurokit2/signal/signal_interpolate.py
+++ b/neurokit2/signal/signal_interpolate.py
@@ -131,7 +131,7 @@ def signal_interpolate(
         )
     elif method == "akima":
         interpolation_function = scipy.interpolate.Akima1DInterpolator(
-            x_values, y_values, extrapolate=True
+            x_values, y_values
         )
     else:
         if fill_value is None:

--- a/neurokit2/signal/signal_interpolate.py
+++ b/neurokit2/signal/signal_interpolate.py
@@ -112,7 +112,7 @@ def signal_interpolate(
         # if x_values is identical to x_new, no need for interpolation
         if np.array_equal(x_values, x_new):
             return y_values
-        elif np.any(x[1:] == x[:-1]):
+        elif np.any(x_values[1:] == x_values[:-1]):
             warn(
                 "Duplicate x values detected. Averaging their corresponding y values.",
                 category=NeuroKitWarning,

--- a/neurokit2/signal/signal_interpolate.py
+++ b/neurokit2/signal/signal_interpolate.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
+from warnings import warn
+
 import numpy as np
 import pandas as pd
 import scipy.interpolate
 
+from ..misc import NeuroKitWarning
 
-def signal_interpolate(x_values, y_values=None, x_new=None, method="quadratic", fill_value=None):
+
+def signal_interpolate(
+    x_values, y_values=None, x_new=None, method="quadratic", fill_value=None
+):
     """**Interpolate a signal**
 
     Interpolate a signal using different methods.
@@ -82,7 +88,9 @@ def signal_interpolate(x_values, y_values=None, x_new=None, method="quadratic", 
     """
     # Sanity checks
     if x_values is None:
-        raise ValueError("NeuroKit error: signal_interpolate(): x_values must be provided.")
+        raise ValueError(
+            "NeuroKit error: signal_interpolate(): x_values must be provided."
+        )
     if y_values is None:
         # for interpolating NaNs
         return _signal_interpolate_nan(x_values, method=method, fill_value=fill_value)
@@ -102,6 +110,14 @@ def signal_interpolate(x_values, y_values=None, x_new=None, method="quadratic", 
         # if x_values is identical to x_new, no need for interpolation
         if np.array_equal(x_values, x_new):
             return y_values
+        elif np.any(x[1:] == x[:-1]):
+            warn(
+                "Duplicate x values detected. Averaging their corresponding y values.",
+                category=NeuroKitWarning,
+            )
+            x_values, y_values = _signal_interpolate_average_duplicates(
+                x_values, y_values
+            )
 
     # If only one value, return a constant signal
     if len(x_values) == 1:
@@ -160,8 +176,18 @@ def _signal_interpolate_nan(values, method="quadratic", fill_value=None):
 
         # interpolate to get the values at the indices where they are missing
         return signal_interpolate(
-            x_values=x_values, y_values=y_values, x_new=x_new, method=method, fill_value=fill_value
+            x_values=x_values,
+            y_values=y_values,
+            x_new=x_new,
+            method=method,
+            fill_value=fill_value,
         )
     else:
         # if there are no missing values, return original values
         return values
+
+
+def _signal_interpolate_average_duplicates(x_values, y_values):
+    unique_x, indices = np.unique(x_values, return_inverse=True)
+    mean_y = np.bincount(indices, weights=y_values) / np.bincount(indices)
+    return unique_x, mean_y

--- a/neurokit2/signal/signal_interpolate.py
+++ b/neurokit2/signal/signal_interpolate.py
@@ -31,13 +31,15 @@ def signal_interpolate(
         first and the last values of x_values.
     method : str
         Method of interpolation. Can be ``"linear"``, ``"nearest"``, ``"zero"``, ``"slinear"``,
-        ``"quadratic"``, ``"cubic"``, ``"previous"``, ``"next"`` or ``"monotone_cubic"``. The
-        methods ``"zero"``, ``"slinear"``,``"quadratic"`` and ``"cubic"`` refer to a spline
+        ``"quadratic"``, ``"cubic"``, ``"previous"``, ``"next"``, ``"monotone_cubic"``, or ``"akima"``.
+        The methods ``"zero"``, ``"slinear"``,``"quadratic"`` and ``"cubic"`` refer to a spline
         interpolation of zeroth, first, second or third order; whereas ``"previous"`` and
         ``"next"`` simply return the previous or next value of the point. An integer specifying the
         order of the spline interpolator to use.
         See `here <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.
         PchipInterpolator.html>`_ for details on the ``"monotone_cubic"`` method.
+        See `here <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.
+        Akima1DInterpolator.html>`_ for details on the ``"akima"`` method.
     fill_value : float or tuple or str
         If a ndarray (or float), this value will be used to fill in for
         requested points outside of the data range.
@@ -125,6 +127,10 @@ def signal_interpolate(
 
     if method == "monotone_cubic":
         interpolation_function = scipy.interpolate.PchipInterpolator(
+            x_values, y_values, extrapolate=True
+        )
+    elif method == "akima":
+        interpolation_function = scipy.interpolate.Akima1DInterpolator(
             x_values, y_values, extrapolate=True
         )
     else:

--- a/tests/tests_ppg.py
+++ b/tests/tests_ppg.py
@@ -8,8 +8,8 @@ import pytest
 import neurokit2 as nk
 
 
-durations = (20, 200)
-sampling_rates = (50, 500)
+durations = (20, 200, 300)
+sampling_rates = (25, 50, 500)
 heart_rates = (50, 120)
 freq_modulations = (0.1, 0.4)
 
@@ -33,6 +33,7 @@ def test_ppg_simulate(duration, sampling_rate, heart_rate, freq_modulation):
         burst_amplitude=0,
         burst_number=0,
         random_state=42,
+        random_state_distort=42,
         show=False,
     )
 

--- a/tests/tests_ppg.py
+++ b/tests/tests_ppg.py
@@ -40,12 +40,13 @@ def test_ppg_simulate(duration, sampling_rate, heart_rate, freq_modulation):
     assert ppg.size == duration * sampling_rate
 
     signals, _ = nk.ppg_process(ppg, sampling_rate=sampling_rate)
-    assert np.allclose(signals["PPG_Rate"].mean(), heart_rate, atol=1)
+    if sampling_rate > 25:
+        assert np.allclose(signals["PPG_Rate"].mean(), heart_rate, atol=1)
 
-    # Ensure that the heart rate fluctuates in the requested range.
-    groundtruth_range = freq_modulation * heart_rate
-    observed_range = np.percentile(signals["PPG_Rate"], 90) - np.percentile(signals["PPG_Rate"], 10)
-    assert np.allclose(groundtruth_range, observed_range, atol=groundtruth_range * 0.15)
+        # Ensure that the heart rate fluctuates in the requested range.
+        groundtruth_range = freq_modulation * heart_rate
+        observed_range = np.percentile(signals["PPG_Rate"], 90) - np.percentile(signals["PPG_Rate"], 10)
+        assert np.allclose(groundtruth_range, observed_range, atol=groundtruth_range * 0.15)
 
     # TODO: test influence of different noise configurations
 


### PR DESCRIPTION
# Description

This PR aims at fixing an error that occurs with `ppg_simulate()` for some parameters (I think smaller sample rates causing duplicate x values corresponding to fiducial points). See also https://github.com/neuropsychology/NeuroKit/issues/832

# Proposed Changes

1. I changed the `ppg_simulate()` function so that it uses `signal_interpolate()`
2. I changed `signal_interpolate()` so that it can process duplicate x values
3. I added the `"akima"` method to `signal_interpolate()`.
4. I added a test case to `test_ppg_simulate()` that was failing in the previous version (longer duration, lower sample rate) to demonstrate how the changes fix the error


# Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targetted at the **dev branch** (and not towards the master branch).