### PR TITLE
[Fix] Fixed memory baviour in hrv calc

### DIFF
--- a/neurokit2/ppg/ppg_intervalrelated.py
+++ b/neurokit2/ppg/ppg_intervalrelated.py
@@ -95,7 +95,7 @@ def ppg_intervalrelated(data, sampling_rate=1000):
 # =============================================================================
 
 
-def _ppg_intervalrelated_formatinput(data: pd.DataFrame):
+def _ppg_intervalrelated_formatinput(data):
     # Sanitize input
     colnames = data.columns.values
 
@@ -112,7 +112,7 @@ def _ppg_intervalrelated_formatinput(data: pd.DataFrame):
     return {"PPG_Rate_Mean": PPG_Rate_Mean}
 
 
-def _ppg_intervalrelated_hrv(data: pd.DataFrame, sampling_rate):
+def _ppg_intervalrelated_hrv(data, sampling_rate):
     # Sanitize input
     colnames = data.columns.values
 

--- a/neurokit2/ppg/ppg_intervalrelated.py
+++ b/neurokit2/ppg/ppg_intervalrelated.py
@@ -79,12 +79,12 @@ def ppg_intervalrelated(data, sampling_rate=1000):
 
             # Rate
             intervals[index] = _ppg_intervalrelated_formatinput(
-                data[index], intervals[index]
+                data[index]
             )
 
             # HRV
             intervals[index] = _ppg_intervalrelated_hrv(
-                data[index], sampling_rate, intervals[index]
+                data[index], sampling_rate
             )
 
         ppg_intervals = pd.DataFrame.from_dict(intervals, orient="index")

--- a/neurokit2/ppg/ppg_intervalrelated.py
+++ b/neurokit2/ppg/ppg_intervalrelated.py
@@ -97,7 +97,9 @@ def ppg_intervalrelated(data, sampling_rate=1000):
 # =============================================================================
 
 
-def _ppg_intervalrelated_formatinput(data, output={}):
+def _ppg_intervalrelated_formatinput(data):
+
+    output={}
 
     # Sanitize input
     colnames = data.columns.values
@@ -113,7 +115,9 @@ def _ppg_intervalrelated_formatinput(data, output={}):
     return output
 
 
-def _ppg_intervalrelated_hrv(data, sampling_rate, output={}):
+def _ppg_intervalrelated_hrv(data, sampling_rate):
+
+    output={}
 
     # Sanitize input
     colnames = data.columns.values

--- a/neurokit2/ppg/ppg_intervalrelated.py
+++ b/neurokit2/ppg/ppg_intervalrelated.py
@@ -72,19 +72,18 @@ def ppg_intervalrelated(data, sampling_rate=1000):
 
     elif isinstance(data, dict):
         for epoch in data:
-
             intervals[epoch] = {}  # Initialize empty container
 
             # Add label info
             intervals[epoch]["Label"] = data[epoch]["Label"].iloc[0]
 
             # Rate
-            intervals[epoch].update(
-                _ppg_intervalrelated_formatinput(data[epoch]))
+            intervals[epoch].update(_ppg_intervalrelated_formatinput(data[epoch]))
 
             # HRV
             intervals[epoch].update(
-                *_ppg_intervalrelated_hrv(data[epoch], sampling_rate))
+                *_ppg_intervalrelated_hrv(data[epoch], sampling_rate)
+            )
 
         ppg_intervals = pd.DataFrame.from_dict(intervals, orient="index")
 
@@ -97,10 +96,9 @@ def ppg_intervalrelated(data, sampling_rate=1000):
 
 
 def _ppg_intervalrelated_formatinput(data: pd.DataFrame):
-
     # Sanitize input
     colnames = data.columns.values
-    
+
     if "PPG_Rate" not in colnames:
         raise ValueError(
             "NeuroKit error: ppg_intervalrelated(): Wrong input,"
@@ -111,12 +109,10 @@ def _ppg_intervalrelated_formatinput(data: pd.DataFrame):
 
     PPG_Rate_Mean = np.mean(signal)
 
-    return {"PPG_Rate_Mean":PPG_Rate_Mean}
+    return {"PPG_Rate_Mean": PPG_Rate_Mean}
 
 
-def _ppg_intervalrelated_hrv(data: pd.DataFrame, 
-                             sampling_rate):
-    
+def _ppg_intervalrelated_hrv(data: pd.DataFrame, sampling_rate):
     # Sanitize input
     colnames = data.columns.values
 
@@ -132,5 +128,5 @@ def _ppg_intervalrelated_hrv(data: pd.DataFrame,
     peaks = {"PPG_Peaks": peaks}
 
     results = hrv(peaks, sampling_rate=sampling_rate)
-    
-    return results.astype("float").to_dict('records')
+
+    return results.astype("float").to_dict("records")

--- a/neurokit2/ppg/ppg_intervalrelated.py
+++ b/neurokit2/ppg/ppg_intervalrelated.py
@@ -61,7 +61,7 @@ def ppg_intervalrelated(data, sampling_rate=1000):
         rate_cols = [col for col in data.columns if "PPG_Rate" in col]
         if len(rate_cols) == 1:
             intervals.update(_ppg_intervalrelated_formatinput(data))
-            intervals.update(_ppg_intervalrelated_hrv(data, sampling_rate))
+            intervals.update(*_ppg_intervalrelated_hrv(data, sampling_rate))
         else:
             raise ValueError(
                 "NeuroKit error: ppg_intervalrelated(): Wrong input,"
@@ -84,7 +84,7 @@ def ppg_intervalrelated(data, sampling_rate=1000):
 
             # HRV
             intervals[epoch].update(
-                _ppg_intervalrelated_hrv(data[epoch], sampling_rate))
+                *_ppg_intervalrelated_hrv(data[epoch], sampling_rate))
 
         ppg_intervals = pd.DataFrame.from_dict(intervals, orient="index")
 
@@ -133,4 +133,4 @@ def _ppg_intervalrelated_hrv(data: pd.DataFrame,
 
     results = hrv(peaks, sampling_rate=sampling_rate)
     
-    return results.astype("float").to_dict()
+    return results.astype("float").to_dict('records')

--- a/neurokit2/ppg/ppg_intervalrelated.py
+++ b/neurokit2/ppg/ppg_intervalrelated.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 import pandas as pd
-from typing import Union
 
 from ..hrv import hrv
 
@@ -102,7 +101,7 @@ def _ppg_intervalrelated_formatinput(data: pd.DataFrame):
     # Sanitize input
     colnames = data.columns.values
     
-    if not "PPG_Rate" in colnames:
+    if "PPG_Rate" not in colnames:
         raise ValueError(
             "NeuroKit error: ppg_intervalrelated(): Wrong input,"
             "we couldn't extract heart rate. Please make sure"
@@ -121,7 +120,7 @@ def _ppg_intervalrelated_hrv(data: pd.DataFrame,
     # Sanitize input
     colnames = data.columns.values
 
-    if not "PPG_Peaks" in colnames:
+    if "PPG_Peaks" not in colnames:
         raise ValueError(
             "NeuroKit error: ppg_intervalrelated(): Wrong input,"
             "we couldn't extract peaks. Please make sure"

--- a/tests/tests_ppg.py
+++ b/tests/tests_ppg.py
@@ -241,5 +241,8 @@ def test_ppg_intervalrelated():
     epochs = nk.epochs_create(
         df, events=[0, 15000], sampling_rate=sampling_rate, epochs_end=150
     )
-    ppg_intervals = nk.ppg_intervalrelated(epochs)
+    epochs_ppg_intervals = nk.ppg_intervalrelated(epochs)
+    assert "PPG_Rate_Mean" in epochs_ppg_intervals.columns
+
+    ppg_intervals = nk.ppg_intervalrelated(df)
     assert "PPG_Rate_Mean" in ppg_intervals.columns


### PR DESCRIPTION
Hello,

while writing some custom code for nk2, I tried gating the calculation of the time-based, frequency-based and non-linear PPG HRV Parameters. While doing that I noticed that, when running the code with all three types of HRV parameters it worked flawlessly - as it is intended using ppg_analyze.

But setting any of the gates to false, did not work, if they have been true before without restarting the kernel. Looking into the issue by extensive testing, I found the following:


In both functions (`_ppg_intervalrelated_hrv(...)` and `_ppg_intervalrelated_formatinput(...)`), the return variable is also in the arguments list for the functions (i.e. `output`):

```
def _ppg_intervalrelated_hrv(data,
                             sampling_rate,
                             output={},
                             ):    

    # Sanitize input
    colnames = data.columns.values
    if len([i for i in colnames if "PPG_Peaks" in i]) == 0:
        raise ValueError(
            "NeuroKit error: ppg_intervalrelated(): Wrong input,"
            "we couldn't extract peaks. Please make sure"
            "your DataFrame contains an `PPG_Peaks` column."
        )

    # Transform rpeaks from "signal" format to "info" format.
    peaks = np.where(data["PPG_Peaks"].values)[0]
    peaks = {"PPG_Peaks": peaks}

    results = hrv(peaks, 
                  sampling_rate=sampling_rate)
    
    for column in results.columns:
        output[column] = float(results[column])

    return output

def _ppg_intervalrelated_formatinput(data, 
                                     output={} 
                                     ):

    # Sanitize input
    colnames = data.columns.values
    if len([i for i in colnames if "PPG_Rate" in i]) == 0:
        raise ValueError(
            "NeuroKit error: ppg_intervalrelated(): Wrong input,"
            "we couldn't extract heart rate. Please make sure"
            "your DataFrame contains an `PPG_Rate` column."
        )
    signal = data["PPG_Rate"].values
    output["PPG_Rate_Mean"] = np.mean(signal)

    return output
```

This leads to some really weird memory behaviour, as it seems the output variable within these functions is not properly destroyed (or at least reset), which is not noticeable if the content of the variable is always the same. It is most noticeable, when the amount of columns / keys within `output` changes between runs. 

The fix is as trivial: just move the initialization of the output dictionary out of the arguments into the actual function body - done.

```
def _ppg_intervalrelated_hrv(data,
                             sampling_rate ):    

    output = {}
   
    # Sanitize input
    colnames = data.columns.values
    if len([i for i in colnames if "PPG_Peaks" in i]) == 0:
        raise ValueError(
            "NeuroKit error: ppg_intervalrelated(): Wrong input,"
            "we couldn't extract peaks. Please make sure"
            "your DataFrame contains an `PPG_Peaks` column."
        )

    # Transform rpeaks from "signal" format to "info" format.
    peaks = np.where(data["PPG_Peaks"].values)[0]
    peaks = {"PPG_Peaks": peaks}

    results = hrv(peaks, 
                  sampling_rate=sampling_rate)
    
    for column in results.columns:
        output[column] = float(results[column])

    return output

def _ppg_intervalrelated_formatinput(data):

   output={}

    # Sanitize input
    colnames = data.columns.values
    if len([i for i in colnames if "PPG_Rate" in i]) == 0:
        raise ValueError(
            "NeuroKit error: ppg_intervalrelated(): Wrong input,"
            "we couldn't extract heart rate. Please make sure"
            "your DataFrame contains an `PPG_Rate` column."
        )
    signal = data["PPG_Rate"].values
    output["PPG_Rate_Mean"] = np.mean(signal)

    return output
```


Cheers