### PR TITLE
[Feature] filter signals with missing data

### DIFF
--- a/neurokit2/signal/signal_filter.py
+++ b/neurokit2/signal/signal_filter.py
@@ -364,6 +364,6 @@ def _signal_filter_missing(signal):
     """Interpolate missing data and save the indices of the missing data."""
     missing = np.where(np.isnan(signal))[0]
     if len(missing) > 0:
-        return signal_interpolate(signal), missing
+        return signal_interpolate(signal, method="linear"), missing
     else:
         return signal, missing

--- a/neurokit2/signal/signal_filter.py
+++ b/neurokit2/signal/signal_filter.py
@@ -6,6 +6,7 @@ import numpy as np
 import scipy.signal
 
 from ..misc import NeuroKitWarning
+from .signal_interpolate import signal_interpolate
 
 
 def signal_filter(
@@ -143,10 +144,12 @@ def signal_filter(
     """
     method = method.lower()
 
+    signal_sanitized, missing = _signal_filter_missing(signal)
+
     if method in ["sg", "savgol", "savitzky-golay"]:
-        filtered = _signal_filter_savgol(signal, sampling_rate, order, window_size=window_size)
+        filtered = _signal_filter_savgol(signal_sanitized, sampling_rate, order, window_size=window_size)
     elif method in ["powerline"]:
-        filtered = _signal_filter_powerline(signal, sampling_rate, powerline)
+        filtered = _signal_filter_powerline(signal_sanitized, sampling_rate, powerline)
     else:
 
         # Sanity checks
@@ -154,21 +157,23 @@ def signal_filter(
             raise ValueError("NeuroKit error: signal_filter(): you need to specify a 'lowcut' or a 'highcut'.")
 
         if method in ["butter", "butterworth"]:
-            filtered = _signal_filter_butterworth(signal, sampling_rate, lowcut, highcut, order)
+            filtered = _signal_filter_butterworth(signal_sanitized, sampling_rate, lowcut, highcut, order)
         elif method in ["butter_ba", "butterworth_ba"]:
-            filtered = _signal_filter_butterworth_ba(signal, sampling_rate, lowcut, highcut, order)
+            filtered = _signal_filter_butterworth_ba(signal_sanitized, sampling_rate, lowcut, highcut, order)
         elif method in ["butter_zi", "butterworth_zi"]:
-            filtered = _signal_filter_butterworth_zi(signal, sampling_rate, lowcut, highcut, order)
+            filtered = _signal_filter_butterworth_zi(signal_sanitized, sampling_rate, lowcut, highcut, order)
         elif method in ["bessel"]:
-            filtered = _signal_filter_bessel(signal, sampling_rate, lowcut, highcut, order)
+            filtered = _signal_filter_bessel(signal_sanitized, sampling_rate, lowcut, highcut, order)
         elif method in ["fir"]:
-            filtered = _signal_filter_fir(signal, sampling_rate, lowcut, highcut, window_size=window_size)
+            filtered = _signal_filter_fir(signal_sanitized, sampling_rate, lowcut, highcut, window_size=window_size)
         else:
             raise ValueError(
                 "NeuroKit error: signal_filter(): 'method' should be",
                 " one of 'butterworth', 'butterworth_ba', 'butterworth_zi', 'bessel',",
                 " 'savgol' or 'fir'.",
             )
+    
+    filtered[missing] = np.nan
 
     if show is True:
         plt.plot(signal, color="lightgrey")
@@ -353,3 +358,12 @@ def _signal_filter_windowsize(window_size="default", sampling_rate=1000):
         if (window_size % 2) == 0:
             window_size + 1  # pylint: disable=W0104
     return window_size
+
+
+def _signal_filter_missing(signal):
+    """Interpolate missing data and save the indices of the missing data."""
+    missing = np.where(np.isnan(signal))[0]
+    if len(missing) > 0:
+        return signal_interpolate(signal), missing
+    else:
+        return signal, missing

--- a/tests/tests_signal.py
+++ b/tests/tests_signal.py
@@ -197,9 +197,14 @@ def test_signal_filter_with_missing():
         nk.ecg_simulate(duration=duration_not_missing, sampling_rate=sampling_rate, noise=noise, random_state=43),
     ]
     )
-    filtered = nk.signal_filter(signal=signal, sampling_rate=sampling_rate, lowcut=0.5, method="butterworth", order=5)
-    filtered = nk.signal_filter(signal=filtered, sampling_rate=sampling_rate, method="powerline")
-    assert filtered.size == signal.size
+    samples = np.arange(len(signal))
+    powerline = np.sin(2 * np.pi * 50 * (samples / sampling_rate))
+    signal_corrupted = signal + powerline
+    signal_clean = nk.signal_filter(
+        signal_corrupted, sampling_rate=sampling_rate, method="powerline"
+    )
+    assert signal_clean.size == signal.size
+    assert np.allclose(sum(signal_clean - signal), -2, atol=0.2, equal_nan=True)
 
 def test_signal_interpolate():
 

--- a/tests/tests_signal.py
+++ b/tests/tests_signal.py
@@ -189,7 +189,7 @@ def test_signal_filter():
 def test_signal_filter_with_missing():
     sampling_rate = 100
     duration_not_missing = 10
-    noise = 0.5
+    noise = 0.0
     signal = np.concatenate(
     [
         nk.ecg_simulate(duration=duration_not_missing, sampling_rate=sampling_rate, noise=noise, random_state=42),
@@ -199,7 +199,7 @@ def test_signal_filter_with_missing():
     )
     filtered = nk.signal_filter(signal=signal, sampling_rate=sampling_rate, lowcut=0.5, method="butterworth", order=5)
     filtered = nk.signal_filter(signal=filtered, sampling_rate=sampling_rate, method="powerline")
-    assert np.nanstd(signal) > np.nanstd(filtered)
+    assert filtered.size == signal.size
 
 def test_signal_interpolate():
 

--- a/tests/tests_signal.py
+++ b/tests/tests_signal.py
@@ -204,7 +204,7 @@ def test_signal_filter_with_missing():
         signal_corrupted, sampling_rate=sampling_rate, method="powerline"
     )
     assert signal_clean.size == signal.size
-    assert np.allclose(sum(signal_clean - signal), -2, atol=0.2, equal_nan=True)
+    assert np.allclose(signal_clean, signal, atol=0.2, equal_nan=True)
 
 def test_signal_interpolate():
 

--- a/tests/tests_signal.py
+++ b/tests/tests_signal.py
@@ -199,7 +199,7 @@ def test_signal_filter_with_missing():
     )
     filtered = nk.signal_filter(signal=signal, sampling_rate=sampling_rate, lowcut=0.5, method="butterworth", order=5)
     filtered = nk.signal_filter(signal=filtered, sampling_rate=sampling_rate, method="powerline")
-    assert np.std(signal) > np.std(filtered)
+    assert np.nanstd(signal) > np.nanstd(filtered)
 
 def test_signal_interpolate():
 

--- a/tests/tests_signal.py
+++ b/tests/tests_signal.py
@@ -189,12 +189,12 @@ def test_signal_filter():
 def test_signal_filter_with_missing():
     sampling_rate = 100
     duration_not_missing = 10
-    noise = 0.0
+    frequency = 2
     signal = np.concatenate(
     [
-        nk.ecg_simulate(duration=duration_not_missing, sampling_rate=sampling_rate, noise=noise, random_state=42),
+        nk.signal_simulate(duration=duration_not_missing, sampling_rate=sampling_rate, frequency=frequency, random_state=42),
         [np.nan] * 1000,
-        nk.ecg_simulate(duration=duration_not_missing, sampling_rate=sampling_rate, noise=noise, random_state=43),
+        nk.signal_simulate(duration=duration_not_missing, sampling_rate=sampling_rate, frequency=frequency, random_state=43),
     ]
     )
     samples = np.arange(len(signal))

--- a/tests/tests_signal.py
+++ b/tests/tests_signal.py
@@ -186,6 +186,20 @@ def test_signal_filter():
 
     assert np.allclose(signal_bandstop, signal_bandstop_scipy, atol=0.2)
 
+def test_signal_filter_with_missing():
+    sampling_rate = 100
+    duration_not_missing = 10
+    noise = 0.5
+    signal = np.concatenate(
+    [
+        nk.ecg_simulate(duration=duration_not_missing, sampling_rate=sampling_rate, noise=noise, random_state=42),
+        [np.nan] * 1000,
+        nk.ecg_simulate(duration=duration_not_missing, sampling_rate=sampling_rate, noise=noise, random_state=43),
+    ]
+    )
+    filtered = nk.signal_filter(signal=signal, sampling_rate=sampling_rate, lowcut=0.5, method="butterworth", order=5)
+    filtered = nk.signal_filter(signal=filtered, sampling_rate=sampling_rate, method="powerline")
+    assert np.std(signal) > np.std(filtered)
 
 def test_signal_interpolate():
 


### PR DESCRIPTION
# Description
As a step towards better handling of missing data (see https://github.com/neuropsychology/NeuroKit/issues/838), this PR aims to allow for filtering signals even if they contain NaNs.

# Proposed Changes

1. I changed the `signal_filter()` function so that NaNs are interpolated before filtering and then added back after filtering.
2. I added `test_signal_filter_with_missing()` to test that the signal containing NaNs is filtered.

# Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).