### PR TITLE
[Fix] typo docstring eda process

### DIFF
--- a/neurokit2/eda/eda_process.py
+++ b/neurokit2/eda/eda_process.py
@@ -20,7 +20,7 @@ def eda_process(eda_signal, sampling_rate=1000, method="neurokit", report=None, 
     eda_signal : Union[list, np.array, pd.Series]
         The raw EDA signal.
     sampling_rate : int
-        The sampling frequency of ``"rsp_signal"`` (in Hz, i.e., samples/second).
+        The sampling frequency of ``"eda_signal"`` (in Hz, i.e., samples/second).
     method : str
         The processing pipeline to apply. Can be one of ``"biosppy"`` or ``"neurokit"`` (default).
     report : str


### PR DESCRIPTION
# Description

This PR fixes a typo in the `eda_process()` docstring mentioned in https://github.com/neuropsychology/NeuroKit/issues/851

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).