### PR TITLE
Fix/docs asyncio warning

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -27,6 +27,7 @@ jobs:
                   pip install sphinx-book-theme
                   pip install sphinxemoji
                   pip install sphinx-copybutton
+                  pip install ipykernel==6.23.2
                   pip install ipython
                   pip install myst-parser
                   pip install myst-nb

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -30,7 +30,6 @@ jobs:
                   pip install ipython
                   pip install myst-parser
                   pip install myst-nb
-                  pip install tornado==6.1
                   pip install numpy
                   pip install pandas
                   pip install scipy

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -30,6 +30,7 @@ jobs:
                   pip install ipython
                   pip install myst-parser
                   pip install myst-nb
+                  pip install tornado==6.1
                   pip install numpy
                   pip install pandas
                   pip install scipy

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -31,7 +31,7 @@ jobs:
                   pip install ipython
                   pip install myst-parser
                   pip install myst-nb
-                  pip install numpy
+                  pip install numpy==1.24.3
                   pip install pandas
                   pip install scipy
                   pip install scikit-learn

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -26,7 +26,7 @@ jobs:
                   pip install ipython
                   pip install myst-parser
                   pip install myst-nb
-                  pip install numpy
+                  pip install numpy==1.24.3
                   pip install pandas
                   pip install scipy
                   pip install scikit-learn

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -22,6 +22,7 @@ jobs:
                   pip install sphinx-book-theme
                   pip install sphinxemoji
                   pip install sphinx-copybutton
+                  pip install ipykernel==6.23.2
                   pip install ipython
                   pip install myst-parser
                   pip install myst-nb

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,8 @@ import datetime
 import os
 import re
 import sys
+import asyncio
+import platform
 
 # -- Path setup --------------------------------------------------------------
 
@@ -105,6 +107,9 @@ nb_execution_raise_on_error = True
 
 # googleanalytics_id = "G-DVXSEGN5M9"
 
+# Address asyncio warning
+if platform.system() == "Windows":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 # NumPyDoc configuration -----------------------------------------------------
 
@@ -135,3 +140,4 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+


### PR DESCRIPTION
# Description

This PR aims to fix the following warning (not sure how to test without opening PR, so wait until docs passes before merging please)
```
D:\a\NeuroKit\NeuroKit\docs\examples\bio_custom\bio_custom.ipynb: Executing notebook using local CWD [mystnb]
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\zmq\_future.py:681: RuntimeWarning: Proactor event loop does not implement add_reader family of methods required for zmq. Registering an additional selector thread for add_reader support via tornado. Use `asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())` to avoid this warning.
  self._get_loop()
```
