### PR TITLE
[FIX] KeyError in _eventrelated_addinfo

### DIFF
--- a/neurokit2/epochs/eventrelated_utils.py
+++ b/neurokit2/epochs/eventrelated_utils.py
@@ -46,7 +46,7 @@ def _eventrelated_sanitizeinput(epochs, what="ecg", silent=False):
 def _eventrelated_addinfo(epoch, output={}):
     # Add label
     if "Index" in epoch.columns:
-        output["Event_Onset"] = epoch.loc[np.min(np.abs(epoch.index))]["Index"]
+        output["Event_Onset"] = epoch.iloc[np.argmin(np.abs(epoch.index))]["Index"]
 
     # Add label
     if "Label" in epoch.columns and len(set(epoch["Label"])) == 1:


### PR DESCRIPTION
Fixes https://github.com/neuropsychology/NeuroKit/issues/867

`_eventrelated_addinfo` in _epochs/eventrelated_utils.py_ has these lines:

```python
if "Index" in epoch.columns:
    output["Event_Onset"] = epoch.loc[np.min(np.abs(epoch.index))]["Index"]
```

`np.min(np.abs(...))` returns the smallest absolute time offset in seconds. If the smallest absolute value is of a negative time offset, then it produces a non-existent index, causing an error when indexing in epoch.loc.

This commit replaces it with `iloc[np.argmin(np.abs(...))]`, indexing by integer index.