### PR TITLE
[Fix] eda_plot throws ValueError when the number of onsets is not the same as the number of peaks

### DIFF
--- a/neurokit2/eda/eda_plot.py
+++ b/neurokit2/eda/eda_plot.py
@@ -62,6 +62,10 @@ def eda_plot(eda_signals, info=None, static=True):
     onsets = np.where(eda_signals["SCR_Onsets"] == 1)[0]
     half_recovery = np.where(eda_signals["SCR_Recovery"] == 1)[0]
 
+    # clean peaks that do not have onsets
+    if len(peaks) > len(onsets):
+        peaks = peaks[1:]
+
     # Determine unit of x-axis.
     x_label = "Time (seconds)"
     x_axis = np.linspace(0, len(eda_signals) / info["sampling_rate"], len(eda_signals))


### PR DESCRIPTION
# Description

Fix a bug where you had an exception if there was not the same number of peaks and onsets (issue #632). This can happen on signal that has been cut (ex: depending on difference conditions). 

# Proposed Changes

The fix just ignores the first peak (only for display) when there is no onset for the first peak.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
