### PR TITLE
Update ecg_segment.py

### DIFF
--- a/neurokit2/ecg/ecg_segment.py
+++ b/neurokit2/ecg/ecg_segment.py
@@ -112,7 +112,7 @@ def _ecg_segment_plot(heartbeats, heartrate=0, ytitle="ECG", color="#F44336", ax
     # Plot average heartbeat
     ax.plot(
         mean_heartbeat.index,
-        mean_heartbeat,
+        mean_heartbeat[col].values,
         color=color,
         linewidth=7,
         label="Average beat shape",


### PR DESCRIPTION
modify plotting error

# Description

I think there was an error referencing the `y` value incorrectly when drawing the segment_plot.
Since the previously declared `mean_heartbeat` is a grouped DataFrame, you need to explicitly specify the columns to get the values correctly.

# Proposed Changes

I changed the `_ecg_segment_plot()` function so that it can properly referencing the `y` value.

