### PR TITLE
fixed sklearn sanity checks for valid_metrics

### DIFF
--- a/neurokit2/complexity/utils.py
+++ b/neurokit2/complexity/utils.py
@@ -111,7 +111,7 @@ def _get_count(
     # -------------------
     # Sanity checks
     sklearn_version = version.parse(sklearn.__version__)
-    if sklearn_version >= version.parse("1.3.0"):
+    if sklearn_version in [version.parse("1.3.0"), version.parse("1.3.0rc1")]:
         valid_metrics = sklearn.neighbors.KDTree.valid_metrics() + ["range"]
     else:
         valid_metrics = sklearn.neighbors.KDTree.valid_metrics + ["range"]


### PR DESCRIPTION
# Description

This PR aims to fix the sklearn.neighbors.KDTree.valid_metrics() sanity check which has been introduced in skearn.__version__ 1.3.0 (and also in 1.3.0rc1), but has afterward been reverted due to compatibility issues with other libraries. More about this can be found here:

https://github.com/scikit-learn/scikit-learn/issues/26742
https://github.com/scikit-learn/scikit-learn/pull/26754

# Proposed Changes

I changed the `if sklearn_version >= version.parse("1.3.0"):` condition to `if sklearn_version in [version.parse("1.3.0"), version.parse("1.3.0rc1")]:` so we can only cover the two cases in which `sklearn.neighbors.KDTree.valid_metrics` is not an attribute and is instead a method.