### PR TITLE
Remove tests from pyproject

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,9 +4,9 @@ include NEWS.rst
 include LICENSE
 include README.rst
 
+recursive-exclude tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py *.jpg *.png *.gif
 
-prune tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,8 +4,9 @@ include NEWS.rst
 include LICENSE
 include README.rst
 
-recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py *.jpg *.png *.gif
+
+prune tests


### PR DESCRIPTION
when install neurokit2 by pip, tests folder in neurokit repository are installed in python env. they can conflict with other local tests directory.

This PR removed tests folder from setup.py by editing MANIFEST.in
