### PR TITLE
[Fix] Fixed rodrigues2021 ECG peaks detector (make it work with < 50Hz sampling rate)

### DIFF
--- a/neurokit2/ecg/ecg_findpeaks.py
+++ b/neurokit2/ecg/ecg_findpeaks.py
@@ -1119,7 +1119,7 @@ def _ecg_findpeaks_rodrigues(signal, sampling_rate=1000, **kwargs):
 
     """
 
-    N = int(np.round(3 * sampling_rate / 128))
+    N = int(np.clip(np.round(3 * sampling_rate / 128), 2, None))
     Nd = N - 1
     Pth = (0.7 * sampling_rate) / 128 + 2.7
     # Pth = 3, optimal for fs = 250 Hz


### PR DESCRIPTION
# Description

This PR aims at fixing a bug where 'Nd' variable in _ecg_findpeaks_rodrigues was set to 0 in case of sampling_rate too small, effectively nulling the ECG first derivative

# Proposed Changes

I have set N to be at least 2, so that Nd is at least 1.


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [X] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [X] My PR is targeted at the **dev branch** (and not towards the master branch).
- [X] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
