### PR TITLE
sparsEDA integration

### DIFF
--- a/neurokit2/eda/eda_phasic.py
+++ b/neurokit2/eda/eda_phasic.py
@@ -492,7 +492,7 @@ def _eda_phasic_sparsEDA(
     SCL = signal_resample(SCL, desired_length=original_length)
     MSE = signal_resample(MSE, desired_length=original_length)
 
-    return driver, SCL, MSE
+    return SCL, signalIn-SCL
 
 
 def lasso(R, s, sampling_rate, maxIters, epsilon):

--- a/neurokit2/eda/eda_phasic.py
+++ b/neurokit2/eda/eda_phasic.py
@@ -357,15 +357,15 @@ def _eda_phasic_sparsEDA(
     if np.sum(np.isnan(eda_signal)) > 0:
         raise AssertionError("Signal contains NaN")
 
-    # Preprocessing
-    signalAdd = np.zeros(len(eda_signal) + (20 * sampling_rate) + (60 * sampling_rate))
-    signalAdd[0 : 20 * sampling_rate] = eda_signal[0]
-    signalAdd[20 * sampling_rate : 20 * sampling_rate + len(eda_signal)] = eda_signal
-    signalAdd[20 * sampling_rate + len(eda_signal) :] = eda_signal[-1]
-
     # Resample to 8 Hz
     eda_signal = signal_resample(eda_signal, sampling_rate=sampling_rate, desired_sampling_rate=8)
     new_sr = 8
+
+    # Preprocessing
+    signalAdd = np.zeros(len(eda_signal) + (20 * new_sr) + (60 * new_sr))
+    signalAdd[0 : 20 * new_sr] = eda_signal[0]
+    signalAdd[20 * new_sr : 20 * new_sr + len(eda_signal)] = eda_signal
+    signalAdd[20 * new_sr + len(eda_signal) :] = eda_signal[-1]
 
     Nss = len(eda_signal)
     Ns = len(signalAdd)
@@ -428,7 +428,7 @@ def _eda_phasic_sparsEDA(
             b0 = signalCut[0]
 
         signalCutIn = signalCut - b0
-        beta, _, _, _, _, _ = lasso(R, signalCutIn, sampling_rate, Kmax, epsilon)
+        beta, _, _, _, _, _ = lasso(R, signalCutIn, new_sr, Kmax, epsilon)
 
         signalEst = (np.matmul(R, beta) + b0).reshape(-1)
 
@@ -488,7 +488,7 @@ def _eda_phasic_sparsEDA(
     threshold = rho * scr_max
     driver[driver < threshold] = 0
 
-    # Resample
+    # Resample back to original sampling rate
     SCL = signal_resample(SCL, desired_length=original_length)
     MSE = signal_resample(MSE, desired_length=original_length)
 

--- a/neurokit2/eda/eda_phasic.py
+++ b/neurokit2/eda/eda_phasic.py
@@ -437,8 +437,8 @@ def _eda_phasic_sparsEDA(
         # res3 = sum(remAout(40*sampling_rate+1:(60*sampling_rate)));
 
         remAout = (signalCut - signalEst) ** 2
-        res2 = np.sum(remAout[20 * sampling_rate : 40 * sampling_rate])
-        res3 = np.sum(remAout[40 * sampling_rate : 60 * sampling_rate])
+        res2 = np.sum(remAout[20 * new_sr : 40 * new_sr])
+        res3 = np.sum(remAout[40 * new_sr : 60 * new_sr])
 
         jump = 1
         if res2 < 1:
@@ -454,14 +454,14 @@ def _eda_phasic_sparsEDA(
         SCRaux[:] = SCRline.reshape([5, Lreg]).transpose()
         driver = SCRaux.sum(axis=1)
 
-        b0 = np.matmul(R[jump * 20 * sampling_rate - 1, 0:6], beta[0:6, :]) + b0
+        b0 = np.matmul(R[jump * 20 * new_sr - 1, 0:6], beta[0:6, :]) + b0
 
-        driverAux[cutS : cutS + (jump * 20 * sampling_rate)] = driver[0 : jump * sampling_rate * 20]
-        slcAux[cutS : cutS + (jump * 20 * sampling_rate)] = SCL[
-            0 : jump * sampling_rate * 20
+        driverAux[cutS : cutS + (jump * 20 * new_sr)] = driver[0 : jump * new_sr * 20]
+        slcAux[cutS : cutS + (jump * 20 * new_sr)] = SCL[
+            0 : jump * new_sr * 20
         ].reshape(-1)
-        resAux[cutS : cutS + (jump * 20 * sampling_rate)] = remAout[0 : jump * sampling_rate * 20]
-        cutS = cutS + jump * 20 * sampling_rate
+        resAux[cutS : cutS + (jump * 20 * new_sr)] = remAout[0 : jump * new_sr * 20]
+        cutS = cutS + jump * 20 * new_sr
         cutE = cutS + N
 
     SCRaux = driverAux[pointerS:pointerE]

--- a/neurokit2/eda/eda_phasic.py
+++ b/neurokit2/eda/eda_phasic.py
@@ -492,7 +492,7 @@ def _eda_phasic_sparsEDA(
     SCL = signal_resample(SCL, desired_length=original_length)
     MSE = signal_resample(MSE, desired_length=original_length)
 
-    return SCL, signalIn-SCL
+    return SCL, eda_signal-SCL
 
 
 def lasso(R, s, sampling_rate, maxIters, epsilon):

--- a/neurokit2/eda/eda_phasic.py
+++ b/neurokit2/eda/eda_phasic.py
@@ -489,10 +489,10 @@ def _eda_phasic_sparsEDA(
     driver[driver < threshold] = 0
 
     # Resample back to original sampling rate
+    SCR = eda_signal-SCL
+    SCR = signal_resample(SCR, desired_length=original_length)
     SCL = signal_resample(SCL, desired_length=original_length)
-    MSE = signal_resample(MSE, desired_length=original_length)
-
-    return SCL, eda_signal-SCL
+    return SCL, SCR
 
 
 def lasso(R, s, sampling_rate, maxIters, epsilon):

--- a/neurokit2/eda/eda_phasic.py
+++ b/neurokit2/eda/eda_phasic.py
@@ -466,7 +466,7 @@ def _eda_phasic_sparsEDA(
 
     SCRaux = driverAux[pointerS:pointerE]
     SCL = slcAux[pointerS:pointerE]
-    MSE = resAux[pointerS:pointerE]
+    #MSE = resAux[pointerS:pointerE]
 
     # PP
     ind = np.argwhere(SCRaux > 0).reshape(-1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.poetry]
 name = "neurokit2"
-version = "0.2.7"  # Needs to find a way to automatically get latest version
+version = "0.2.8"  # Needs to find a way to automatically get latest version
 description = "The Python Toolbox for Neurophysiological Signal Processing."
 authors = [
     "Dominique Makowski <@DominiqueMakowski>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.poetry]
 name = "neurokit2"
-# version = "0.1.0"  # Needs to find a way to automatically get latest version
+version = "0.2.7"  # Needs to find a way to automatically get latest version
 description = "The Python Toolbox for Neurophysiological Signal Processing."
 authors = [
     "Dominique Makowski <@DominiqueMakowski>",
@@ -24,7 +24,12 @@ keywords = ['python', 'neurokit', 'neurokit2', 'physiological', 'signal']
 
 
 [tool.poetry.dependencies]
-python = "*"
+python = "^3.11"
+scipy = "^1.11"
+scikit-learn = "^1.4"
+pandas = "^2.1"
+matplotlib = "*"
+requests = "^2.31.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ scikit-learn = "^1.4"
 pandas = "^2.1"
 matplotlib = "*"
 requests = "^2.31.0"
+cvxopt = "^1.3"
+biosppy = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.4"

--- a/tests/tests_eda.py
+++ b/tests/tests_eda.py
@@ -81,9 +81,8 @@ def test_eda_phasic():
     highpass = nk.eda_phasic(eda, sampling_rate=sr, method="highpass")
     assert len(highpass) == len(eda)
 
-    # This fails unfortunately... need to fix the sparsEDA algorithm
-    # sparsEDA = nk.eda_phasic(eda, sampling_rate=sr, method="sparsEDA")
-    # assert len(highpass) == len(eda)
+    sparsEDA = nk.eda_phasic(eda, sampling_rate=sr, method="sparsEDA")
+    assert len(highpass) == len(eda)
 
 
 def test_eda_peaks():

--- a/tests/tests_eda.py
+++ b/tests/tests_eda.py
@@ -82,7 +82,7 @@ def test_eda_phasic():
     assert len(highpass) == len(eda)
 
     sparsEDA = nk.eda_phasic(eda, sampling_rate=sr, method="sparsEDA")
-    assert len(highpass) == len(eda)
+    assert len(sparsEDA) == len(eda)
 
 
 def test_eda_peaks():


### PR DESCRIPTION
The sparsEDA algorithm detects the tonic component in EDA and returns: a `driver`, `SCL` (tonic component), and `MSE` (residual). This is incompable with `eda_phasic()` which expects a `(tonic,phasic)` pair, see also Issue https://github.com/neuropsychology/NeuroKit/issues/964 .

This PR resolves Issue https://github.com/neuropsychology/NeuroKit/issues/964 by making `_eda_phasic_sparsEDA()` return a `(tonic,phasic)` pair where `tonic` is `SCL` and `phasic` is the difference between the original signal and the tonic component detected by sparsEDA,