### PR TITLE
[Fix] Syntax to get colormap

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,6 +133,7 @@ html_theme_options = {
     "use_edit_page_button": True,
     "logo_only": True,
     "show_toc_level": 1,
+    "navigation_with_keys": False,
 }
 
 

--- a/neurokit2/complexity/entropy_phase.py
+++ b/neurokit2/complexity/entropy_phase.py
@@ -123,7 +123,7 @@ def entropy_phase(signal, delay=1, k=4, show=False, **kwargs):
         Tx = Tx.astype(bool)
         Ys = np.sin(angles) * limx * np.sqrt(2)
         Xs = np.cos(angles) * limx * np.sqrt(2)
-        colors = plt.get_cmap("jet")(np.linspace(0, 1, k))
+        colors = plt.get_cmap("jet").resampled(k)
 
         plt.figure()
         for i in range(k):

--- a/neurokit2/events/events_plot.py
+++ b/neurokit2/events/events_plot.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import matplotlib.cm
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd

--- a/neurokit2/events/events_plot.py
+++ b/neurokit2/events/events_plot.py
@@ -127,7 +127,7 @@ def events_plot(events, signal=None, color="red", linestyle="--"):
     else:
         # Convert color and style to list
         if isinstance(color, str):
-            color_map = matplotlib.cm.get_cmap("rainbow")
+            color_map = plt.get_cmap("rainbow")
             color = color_map(np.linspace(0, 1, num=len(events)))
         if isinstance(linestyle, str):
             linestyle = np.full(len(events), linestyle)

--- a/neurokit2/hrv/hrv_nonlinear.py
+++ b/neurokit2/hrv/hrv_nonlinear.py
@@ -542,7 +542,7 @@ def _hrv_nonlinear_show(rri, rri_time=None, rri_missing=False, out={}, ax=None, 
     kernel = scipy.stats.gaussian_kde(values)
     f = np.reshape(kernel(positions).T, xx.shape)
 
-    cmap = matplotlib.cm.get_cmap("Blues", 10)
+    cmap = plt.get_cmap("Blues")(np.linspace(0, 1, 10))
     ax.contourf(xx, yy, f, cmap=cmap)
     ax.imshow(np.rot90(f), extent=[ax1_min, ax1_max, ax2_min, ax2_max], aspect="auto")
 

--- a/neurokit2/hrv/hrv_nonlinear.py
+++ b/neurokit2/hrv/hrv_nonlinear.py
@@ -542,7 +542,7 @@ def _hrv_nonlinear_show(rri, rri_time=None, rri_missing=False, out={}, ax=None, 
     kernel = scipy.stats.gaussian_kde(values)
     f = np.reshape(kernel(positions).T, xx.shape)
 
-    cmap = plt.get_cmap("Blues")(np.linspace(0, 1, 10))
+    cmap = plt.get_cmap("Blues").resampled(10)
     ax.contourf(xx, yy, f, cmap=cmap)
     ax.imshow(np.rot90(f), extent=[ax1_min, ax1_max, ax2_min, ax2_max], aspect="auto")
 

--- a/neurokit2/microstates/microstates_plot.py
+++ b/neurokit2/microstates/microstates_plot.py
@@ -99,7 +99,7 @@ def microstates_plot(microstates, segmentation=None, gfp=None, info=None, epoch=
     if epoch is None:
         epoch = (0, len(gfp))
 
-    cmap = plt.get_cmap("plasma")(np.linspace(0, 1, n))
+    cmap = plt.get_cmap("plasma").resampled(n)
     # Plot the GFP line above the area
     ax["GFP"].plot(
         times[epoch[0] : epoch[1]], gfp[epoch[0] : epoch[1]], color="black", linewidth=0.5

--- a/neurokit2/microstates/microstates_plot.py
+++ b/neurokit2/microstates/microstates_plot.py
@@ -99,7 +99,7 @@ def microstates_plot(microstates, segmentation=None, gfp=None, info=None, epoch=
     if epoch is None:
         epoch = (0, len(gfp))
 
-    cmap = plt.cm.get_cmap("plasma", n)
+    cmap = plt.get_cmap("plasma")(np.linspace(0, 1, n))
     # Plot the GFP line above the area
     ax["GFP"].plot(
         times[epoch[0] : epoch[1]], gfp[epoch[0] : epoch[1]], color="black", linewidth=0.5

--- a/neurokit2/signal/signal_power.py
+++ b/neurokit2/signal/signal_power.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import matplotlib.cm
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd

--- a/neurokit2/signal/signal_power.py
+++ b/neurokit2/signal/signal_power.py
@@ -193,7 +193,7 @@ def _signal_power_instant_plot(psd, out, frequency_band, ax=None):
         labels = [f"{i[1]}-{i[2]} Hz" for i in labels]
 
     # Get cmap
-    cmap = matplotlib.cm.get_cmap("Set1")
+    cmap = plt.get_cmap("Set1")
     colors = cmap.colors
     colors = (
         colors[3],


### PR DESCRIPTION
# Description

This PR aims to address failing checks such as https://github.com/neuropsychology/NeuroKit/actions/runs/9143576310/job/25140400276?pr=987 that seem to be caused by the current version of `matplotlib` being incompatible with the `matplotlib.cm.get_cmap` syntax.

# Proposed Changes

I changed all instances of `matplotlib.cm.get_cmap()` to `plt.get_cmap()`

# Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
