### PR TITLE
[Docs] fix location of misplaced double quotes in docstring of ecg_quality.py

### DIFF
--- a/neurokit2/ecg/ecg_quality.py
+++ b/neurokit2/ecg/ecg_quality.py
@@ -56,7 +56,7 @@ def ecg_quality(ecg_cleaned, rpeaks=None, sampling_rate=1000, method="averageQRS
     array or str
         Vector containing the quality index ranging from 0 to 1 for ``"averageQRS"`` method,
         returns string classification (``Unacceptable``, ``Barely Acceptable`` or ``Excellent``)
-        of the signal for ``"zhao2018 method"``.
+        of the signal for ``"zhao2018"`` method.
 
     See Also
     --------


### PR DESCRIPTION
# Description

This PR aims at fixing the location of a misplaced double quote in the docstring of ecg_quality.py. This would be my first open source contribution :)
