### PR TITLE
return frequency in `signal.signal_filter._signal_filter_sanitize` as scalar

### DIFF
--- a/neurokit2/signal/signal_filter.py
+++ b/neurokit2/signal/signal_filter.py
@@ -338,10 +338,10 @@ def _signal_filter_sanitize(lowcut=None, highcut=None, sampling_rate=1000, norma
         # pass frequencies in order of lowest to highest to the scipy filter
         freqs = list(np.sort([lowcut, highcut]))
     elif lowcut is not None:
-        freqs = [lowcut]
+        freqs = lowcut
         filter_type = "highpass"
     elif highcut is not None:
-        freqs = [highcut]
+        freqs = highcut
         filter_type = "lowpass"
 
     # Normalize frequency to Nyquist Frequency (Fs/2).


### PR DESCRIPTION
# Description

In order to avoid the DeprecationWarning thrown by NumPy (`DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)`) , the `freq` variable should be returned as a scalar and not as a list 

# Proposed Changes

Change the `freqs` variable from list to a scalar when filter is either `lowpass` or `highpass`


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
