### PR TITLE
[Fix] Return an empty array rather than throwing an exception if no QRS dat…

### DIFF
--- a/neurokit2/ecg/ecg_findpeaks.py
+++ b/neurokit2/ecg/ecg_findpeaks.py
@@ -274,6 +274,9 @@ def _ecg_findpeaks_neurokit(
     qrs = smoothgrad > gradthreshold
     beg_qrs = np.where(np.logical_and(np.logical_not(qrs[0:-1]), qrs[1:]))[0]
     end_qrs = np.where(np.logical_and(qrs[0:-1], np.logical_not(qrs[1:])))[0]
+
+    if len(beg_qrs) == 0:
+        return []
     # Throw out QRS-ends that precede first QRS-start.
     end_qrs = end_qrs[end_qrs > beg_qrs[0]]
 

--- a/neurokit2/ecg/ecg_findpeaks.py
+++ b/neurokit2/ecg/ecg_findpeaks.py
@@ -276,7 +276,8 @@ def _ecg_findpeaks_neurokit(
     end_qrs = np.where(np.logical_and(qrs[0:-1], np.logical_not(qrs[1:])))[0]
 
     if len(beg_qrs) == 0:
-        return []
+        return np.array([])
+    
     # Throw out QRS-ends that precede first QRS-start.
     end_qrs = end_qrs[end_qrs > beg_qrs[0]]
 
@@ -503,6 +504,14 @@ def _ecg_findpeaks_zong(signal, sampling_rate=1000, cutoff=16, window=0.13, **kw
     ret = np.pad(clt, (window_size - 1, 0), "constant", constant_values=(0, 0))
     ret = np.convolve(ret, np.ones(window_size), "valid")
 
+    # Check that ret is at least as large as the window
+    if len(ret) < window_size:
+        warn(
+            f"The signal must be at least {window_size} samples long for peak detection with the Zong method. ",
+            category=NeuroKitWarning,
+        )
+        return np.array([])
+
     for i in range(1, window_size):
         ret[i - 1] = ret[i - 1] / i
     ret[window_size - 1 :] = ret[window_size - 1 :] / window_size
@@ -638,7 +647,8 @@ def _ecg_findpeaks_christov(signal, sampling_rate=1000, **kwargs):
                 if len(RR) > 5:
                     RR.pop(0)
                 Rm = int(np.mean(RR))
-
+    if len(QRS) == 0:
+        return np.array([])
     QRS.pop(0)
     QRS = np.array(QRS, dtype="int")
     return QRS
@@ -919,6 +929,9 @@ def _ecg_findpeaks_engzee(signal, sampling_rate=1000, **kwargs):
             thi = False
             thf = False
 
+    if len(r_peaks) == 0:
+        return np.array([])
+    
     r_peaks.pop(
         0
     )  # removing the 1st detection as it 1st needs the QRS complex amplitude for the threshold
@@ -959,6 +972,12 @@ def _ecg_findpeaks_manikandan(signal, sampling_rate=1000, **kwargs):
 
     # Eq. 1: First-order differencing difference
     dn = np.append(filtered[1:], 0) - filtered
+
+    # If the signal is flat then return an empty array rather than error out
+    # with a divide by zero error.
+    if np.max(abs(dn)) == 0:
+        return np.array([])
+    
     # Eq. 2
     dtn = dn / (np.max(abs(dn)))
 

--- a/tests/tests_ecg_findpeaks.py
+++ b/tests/tests_ecg_findpeaks.py
@@ -3,6 +3,7 @@ import os.path
 
 import numpy as np
 import pandas as pd
+import pytest
 
 # Trick to directly access internal functions for unit testing.
 #
@@ -24,22 +25,16 @@ def _read_csv_column(csv_name, column):
     csv_data = pd.read_csv(csv_path, header=None)
     return csv_data[column].to_numpy()
 
-def test_ecg_findpeaks_all_methods_handle_empty_input():
-    METHODS = ["neurokit", "pantompkins", "nabian", "gamboa", 
+#vgraph is not included because it currently causes CI to fail (issue 1007)    
+@pytest.mark.parametrize("method",["neurokit", "pantompkins", "nabian", "gamboa", 
                "slopesumfunction", "wqrs", "hamilton", "christov",
                "engzee", "manikandan", "elgendi", "kalidas", 
-               "martinez", "rodrigues"]
-    
-    failed_methods = []
-    for method in METHODS:
-        try:
-            method_func = _ecg_findpeaks_findmethod(method)
-            _ = method_func(np.zeros(12*240), sampling_rate=240)
-        except Exception:
-            failed_methods.append(method)
-            continue
-    if failed_methods:
-        raise Exception(f"Failed methods: {failed_methods}")
+               "martinez", "rodrigues",])
+def test_ecg_findpeaks_all_methods_handle_empty_input(method):
+    method_func = _ecg_findpeaks_findmethod(method)
+    # The test here is implicit: no exceptions means that it passed,
+    # even if the output is nonsense.
+    _ = method_func(np.zeros(12*240), sampling_rate=240)
 
 
 def test_ecg_findpeaks_MWA():

--- a/tests/tests_ecg_findpeaks.py
+++ b/tests/tests_ecg_findpeaks.py
@@ -13,6 +13,7 @@ from neurokit2.ecg.ecg_findpeaks import (
     _ecg_findpeaks_MWA,
     _ecg_findpeaks_peakdetect,
     _ecg_findpeaks_hamilton,
+    _ecg_findpeaks_findmethod,
 )
 
 
@@ -22,6 +23,23 @@ def _read_csv_column(csv_name, column):
     )
     csv_data = pd.read_csv(csv_path, header=None)
     return csv_data[column].to_numpy()
+
+def test_ecg_findpeaks_all_methods_handle_empty_input():
+    METHODS = ["neurokit", "pantompkins", "nabian", "gamboa", 
+               "slopesumfunction", "wqrs", "hamilton", "christov",
+               "engzee", "manikandan", "elgendi", "kalidas", 
+               "martinez", "rodrigues", "vgraph"]
+    
+    failed_methods = []
+    for method in METHODS:
+        try:
+            method_func = _ecg_findpeaks_findmethod(method)
+            _ = method_func(np.zeros(12*240), sampling_rate=240)
+        except Exception:
+            failed_methods.append(method)
+            continue
+
+    np.testing.assert_equal(failed_methods, [])
 
 
 def test_ecg_findpeaks_MWA():

--- a/tests/tests_ecg_findpeaks.py
+++ b/tests/tests_ecg_findpeaks.py
@@ -28,7 +28,7 @@ def test_ecg_findpeaks_all_methods_handle_empty_input():
     METHODS = ["neurokit", "pantompkins", "nabian", "gamboa", 
                "slopesumfunction", "wqrs", "hamilton", "christov",
                "engzee", "manikandan", "elgendi", "kalidas", 
-               "martinez", "rodrigues", "vgraph"]
+               "martinez", "rodrigues"]
     
     failed_methods = []
     for method in METHODS:
@@ -38,8 +38,8 @@ def test_ecg_findpeaks_all_methods_handle_empty_input():
         except Exception:
             failed_methods.append(method)
             continue
-
-    np.testing.assert_equal(failed_methods, [])
+    if failed_methods:
+        raise Exception(f"Failed methods: {failed_methods}")
 
 
 def test_ecg_findpeaks_MWA():


### PR DESCRIPTION
# Description

This PR aims fixes an error where running ecg_peakdetect on a signal without any QRS complexes would throw an exception rather than returning an empty array. There are a couple of issues (mostly closed due to inactivity) that relate to this: #580, #472, #134

# Proposed Changes

I changed the `_ecg_findpeaks_neurokit()` function so that the length of `beg_qrs` is checked before accessing the first element. If the array is empty then return an empty array rather than triggering a ValueException.


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [x] I have added the newly added features to **News.rst** (if applicable)
