### PR TITLE
[Fix] Documentation Image Dependency

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -44,6 +44,7 @@ jobs:
                   pip install EMD-signal
                   pip install cvxopt
                   pip install ts2vg
+                  pip install pickleshare
                   pip install https://github.com/neuropsychology/neurokit/zipball/dev
 
             - name: Build documentation 📜


### PR DESCRIPTION
The example images were not working for a while on the documentation website and I was curious as to what was wrong. It turns out that ipython at some point made the pickleshare dependency optional which meant that it was not automatically installed in the doc building workflow. I found the solution here on this issue ipython/ipython#14367. The solution is either to add pickleshare as a dependency or to update IPython. In this pull request I have simply gone with adding pickleshare as a dependency to get the images back online asap. Updating the remaining dependencies would be a topic for a different thread.

# Description

This PR fixes the issue #999 and allows users to be able to see the examples again on the documentation website. Here is the example from the issue with the actual image to see the result:
![image-fix](https://github.com/user-attachments/assets/485c63de-6c26-4c62-869d-4e7e205a9b62)


# Proposed Changes

I added pickleshare as a dependency for the docs-build to allow for the doc image files to be stored in the correct location.
