### PR TITLE
[Fix] findpeaks neurokit index error

### DIFF
--- a/neurokit2/ecg/ecg_findpeaks.py
+++ b/neurokit2/ecg/ecg_findpeaks.py
@@ -1245,6 +1245,10 @@ def _ecg_findpeaks_visibilitygraph(
     weights = np.zeros(N)  # Empty array to store the weights
     BETA = 0.55  # Target number of nonzero elements in the resulting weight vector
 
+    # if the input signal is flat, return an empty array, otherwise the visiblity graph will fail
+    if np.max(signal) == np.min(signal):
+        return np.array([])
+
     # If input length is smaller than window, compute only one segment of this length
     if N < M:
         M, R = N, N

--- a/tests/tests_ecg_findpeaks.py
+++ b/tests/tests_ecg_findpeaks.py
@@ -25,11 +25,11 @@ def _read_csv_column(csv_name, column):
     csv_data = pd.read_csv(csv_path, header=None)
     return csv_data[column].to_numpy()
 
-#vgraph is not included because it currently causes CI to fail (issue 1007)    
+
 @pytest.mark.parametrize("method",["neurokit", "pantompkins", "nabian", "gamboa", 
                "slopesumfunction", "wqrs", "hamilton", "christov",
                "engzee", "manikandan", "elgendi", "kalidas", 
-               "martinez", "rodrigues",])
+               "martinez", "rodrigues", "vgraph"])
 def test_ecg_findpeaks_all_methods_handle_empty_input(method):
     method_func = _ecg_findpeaks_findmethod(method)
     # The test here is implicit: no exceptions means that it passed,


### PR DESCRIPTION
# Description

In working on #1007 I added logic to ensure that the find_peaks functions all worked when there were no peaks detected. We couldn't work on `_ecg_findpeaks_visibilitygraph` because ts2vg was broken in CI. Well https://github.com/CarlosBergillos/ts2vg/issues/36 (#1009 here) is fixed now and a new version is on pypi. This PR finishes what #1007 started. 

# Proposed Changes

I added flat signal checking to `_ecg_findpeaks_visibilitygraph` -- if the min/max of the signal is equal then return an empty array


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [x] I have added the newly added features to **News.rst** (if applicable)
