### PR TITLE
[Fix] GUDB name consistency

### DIFF
--- a/data/gudb/download_gudb.py
+++ b/data/gudb/download_gudb.py
@@ -41,7 +41,7 @@ for participant in range(25):
             anno = pd.DataFrame({"Rpeaks": ecg_class.anno_cs})
             anno["Participant"] = "GUDB_%.2i" %(participant)
             anno["Sampling_Rate"] = 250
-            anno["Database"] = "GUDB (" + experiment + ")"
+            anno["Database"] = "GUDB_" + experiment
 
             # Store with the rest
             dfs_ecg.append(data)

--- a/data/gudb/download_gudb.py
+++ b/data/gudb/download_gudb.py
@@ -28,7 +28,7 @@ for participant in range(25):
         # creating class which loads the experiment
         ecg_class = ecg_gudb_database.GUDb(participant, experiment)
 
-        # Chest Strap Data - only donwload if R-peaks annotations are available
+        # Chest Strap Data - only download if R-peaks annotations are available
         if ecg_class.anno_cs_exists:
 
             data = pd.DataFrame({"ECG": ecg_class.cs_V2_V1})


### PR DESCRIPTION
# Description

This PR aims to improve consistency in the naming of the GUDB database for R-Peak annotations and raw ECG data. I think a difference in naming could be problematic when selecting subsets of data for benchmarking:

https://github.com/neuropsychology/NeuroKit/blob/d42a2306a68efb5f59e5a86b4fac95dc5ff5359b/neurokit2/benchmark/benchmark_ecg.py#L83-L85

# Proposed Changes

I changed `download_gudb.py` so that the database name for R-peaks uses an underscore instead of parentheses:
https://github.com/neuropsychology/NeuroKit/blob/d42a2306a68efb5f59e5a86b4fac95dc5ff5359b/data/gudb/download_gudb.py#L44

Such that it matches the corresponding name for raw ECG data:
https://github.com/neuropsychology/NeuroKit/blob/d42a2306a68efb5f59e5a86b4fac95dc5ff5359b/data/gudb/download_gudb.py#L38

# Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.