### PR TITLE
Fix: Lightmode now shows text correctly for the codebook

### DIFF
--- a/docs/codebook.rst
+++ b/docs/codebook.rst
@@ -23,8 +23,6 @@ Codebook Table
     #csvDataTable {
         width: 100%;
         border-collapse: collapse;
-        .. background-color: #f8f8f8;
-        color: white;
     }
     #csvDataTable th, #csvDataTable td {
         padding: 8px 12px;


### PR DESCRIPTION
# Description

The problem was definitely mine. I left a `color: white` tag in the css of the cells.

# Proposed Changes

Remove the css tag


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
