### PR TITLE
[docs] Fix the docstring in eda_process for SCR_RiseTime

### DIFF
--- a/neurokit2/eda/eda_process.py
+++ b/neurokit2/eda/eda_process.py
@@ -50,7 +50,7 @@ def eda_process(
             SCR_Height|The SCR amplitude of the signal including the Tonic component. Note that cumulative \
                 effects of close-occurring SCRs might lead to an underestimation of the amplitude.
             SCR_Amplitude|The SCR amplitude of the signal excluding the Tonic component.
-            SCR_RiseTime|The SCR amplitude of the signal excluding the Tonic component.
+            SCR_RiseTime|The time taken for SCR onset to reach peak amplitude within the SCR.
             SCR_Recovery|The samples at which SCR peaks recover (decline) to half amplitude, marked  as "1" \
                 in a list of zeros.
 


### PR DESCRIPTION
There was a human error in converting the docstrings in `eda_process.py` during the codebook conversion. SCR_RiseTime had the same description as SCR_Amplitude after the change. This PR reverts the description to what it was before.

This PR closes #1031 .

# Description

Fix a docstring mistake while migrating to the new standard.

# Proposed Changes
Revert docstring value to what it was before.


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
