### PR TITLE
[Change] Update ppg_quality.py to use consistent interpolation method ('previous')

### DIFF
--- a/neurokit2/ppg/ppg_quality.py
+++ b/neurokit2/ppg/ppg_quality.py
@@ -138,7 +138,7 @@ def _ppg_quality_templatematch(ppg_cleaned, ppg_pw_peaks=None, sampling_rate=100
 
     # Interpolate beat-by-beat CCs
     quality = signal_interpolate(
-        ppg_pw_peaks[0:-1], cc, x_new=np.arange(len(ppg_cleaned)), method="quadratic"
+        ppg_pw_peaks[0:-1], cc, x_new=np.arange(len(ppg_cleaned)), method="previous"
     )
 
     return quality


### PR DESCRIPTION
# Description

This PR aims at adding this feature...
Addressing issue #1043
Standardizing the interpolation step of the ppg_quality pipeline.

# Proposed Changes

Within ppg_quality, changed 'templatematch' implementation to use interpolation method 'previous' rather than 'quadratic'. This aligns it with the 'disimilarity' implementation and is a better representation of the beat-by-beat nature of the quality measure.


# Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [X] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
