### PR TITLE
[Docs] Add a note about the units used for the time-based HRV metrics.

### DIFF
--- a/neurokit2/hrv/hrv_time.py
+++ b/neurokit2/hrv/hrv_time.py
@@ -91,6 +91,11 @@ def hrv_time(peaks, sampling_rate=1000, show=False, **kwargs):
     --------
     ecg_peaks, ppg_peaks, hrv_frequency, hrv_summary, hrv_nonlinear
 
+    Notes
+    -----
+
+    Where applicable, the unit used for these metrics is the millisecond.
+
     Examples
     --------
     .. ipython:: python


### PR DESCRIPTION
# Description

This PR aims at improving the docstring of `hrv_time` function. This PR should fix https://github.com/neuropsychology/NeuroKit/issues/1046. 

# Proposed Changes

I added a note to the docstring stating that "Where applicable, the unit used for these metrics is the millisecond."


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [X ] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [X ] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.

