### PR TITLE
[Change] ecg_quality interpolation from quadratic to "previous"

### DIFF
--- a/neurokit2/ecg/ecg_quality.py
+++ b/neurokit2/ecg/ecg_quality.py
@@ -157,7 +157,7 @@ def _ecg_quality_averageQRS(ecg_cleaned, rpeaks=None, sampling_rate=1000):
 
     # Interpolate
     quality = signal_interpolate(
-        rpeaks, quality, x_new=np.arange(len(ecg_cleaned)), method="linear"
+        rpeaks, quality, x_new=np.arange(len(ecg_cleaned)), method="previous"
     )
 
     return quality

--- a/neurokit2/ecg/ecg_quality.py
+++ b/neurokit2/ecg/ecg_quality.py
@@ -157,7 +157,7 @@ def _ecg_quality_averageQRS(ecg_cleaned, rpeaks=None, sampling_rate=1000):
 
     # Interpolate
     quality = signal_interpolate(
-        rpeaks, quality, x_new=np.arange(len(ecg_cleaned)), method="quadratic"
+        rpeaks, quality, x_new=np.arange(len(ecg_cleaned)), method="linear"
     )
 
     return quality


### PR DESCRIPTION
# Description

Fix issue https://github.com/neuropsychology/NeuroKit/issues/1052: `ecg_quality` is unbounded because of quadratic interpolation.

# Proposed Changes

change interpolation to `linear`


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
