### PR TITLE
Fix: nk.data import of eeg sample data

### DIFF
--- a/neurokit2/data/data.py
+++ b/neurokit2/data/data.py
@@ -4,7 +4,9 @@ import os
 import pickle
 import urllib
 
+import mne
 import pandas as pd
+
 from sklearn import datasets as sklearn_datasets
 
 
@@ -194,9 +196,7 @@ def data(dataset="bio_eventrelated_100hz"):
     # Dataframes ===============================
     if dataset == "iris":
         info = sklearn_datasets.load_iris()
-        data = pd.DataFrame(
-            info.data, columns=["Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"]
-        )
+        data = pd.DataFrame(info.data, columns=["Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"])
         data["Species"] = info.target_names[info.target]
         return data
 
@@ -225,11 +225,18 @@ def data(dataset="bio_eventrelated_100hz"):
     # TODO: Add more EEG (fif and edf datasets)
     if dataset in ["eeg_1min_200hz"]:
 
-        return pickle.load(
+        eeg_object = pickle.load(
             urllib.request.urlopen(
                 "https://github.com/neuropsychology/NeuroKit/blob/dev/data/eeg_1min_200hz.pickle?raw=true"
             )
         )
+
+        # Pickle includes filename which MNE (1.9) now checks when cropping signal
+        # see https://github.com/mne-tools/mne-python/pull/12843
+        if tuple(map(int, mne.__version__.split("."))) >= (1, 9, 0):
+            eeg_object.filenames = (None,)
+
+        return eeg_object
 
     # General case
     file, ext = os.path.splitext(dataset)  # pylint: disable=unused-variable


### PR DESCRIPTION
# TL;DR
- Mne 1.9 changes how cropping works to include file checks (see https://github.com/mne-tools/mne-python/pull/12843 )
- Sample data is stored in pickle so does not come from disk
- Change removes previous existing filenames from eeg sample data

# Description

This PR fixes the documentation issue as one of the files uses the sample eeg data. The problem stems from the most recent version of mne which has a function which removes the filenames (and checks for their existence on disk!!) when trying to crop the data. The motivation here seems to be that it can remove the filenames if the crop range is out of scope of a file.

This caused issues, since the current version of the eeg sample data is imported via a pickle rather than eeg data itself. This included metadata that was relevant for the uploader, but of course the file name does not exist in this case.

Due to this, it was not possible to use the sample data and therefore the documentation pipeline could not work.

# Proposed Changes

The current proposal is to check for the version number and if it is greater than or equal to 1.9, then it removes the filenames from the eeg data. The change makes sense as there is in fact no filename connected to the in-memory file that came from the pickle, however, I am also not too sure if it looks too "hacky".

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
