### PR TITLE
[Update] changes scipy.signal.daub to PyWavelets format

### DIFF
--- a/neurokit2/ecg/ecg_simulate.py
+++ b/neurokit2/ecg/ecg_simulate.py
@@ -4,6 +4,7 @@ import math
 import numpy as np
 import pandas as pd
 import scipy
+import pywt
 
 from ..misc import check_random_state, check_random_state_children
 from ..signal import signal_distort, signal_resample
@@ -207,7 +208,7 @@ def _ecg_simulate_daubechies(duration=10, length=None, sampling_rate=1000, heart
 
     """
     # The "Daubechies" wavelet is a rough approximation to a real, single, cardiac cycle
-    cardiac = scipy.signal.daub(10)
+    cardiac = np.array(pywt.Wavelet("db10").rec_lo)
 
     # Add the gap after the pqrst when the heart is resting.
     cardiac = np.concatenate([cardiac, np.zeros(10)])


### PR DESCRIPTION
# TL;DR
- Changes due to removal of wavelets from scipy in 1.15

# Description

scipy no longer does wavelets and recommends to use PyWavelet and addresses the issue from https://github.com/neuropsychology/NeuroKit/pull/1022#issuecomment-2653884456 .