### PR TITLE
[Fix] Disable HRV DFA computation on signals with less than 12 rri

### DIFF
--- a/neurokit2/hrv/hrv_nonlinear.py
+++ b/neurokit2/hrv/hrv_nonlinear.py
@@ -498,6 +498,13 @@ def _hrv_dfa(rri, out, n_windows="default", **kwargs):
     # else:
     # dfa_windows = [(4, 11), (12, None)]
     # consider using dict.get() mthd directly
+
+    # If the signal is too short, skip it
+    if len(rri) < 12:
+        out['DFA_alpha1'] = np.nan
+        out['DFA_alpha2'] = np.nan
+        return out
+
     dfa_windows = kwargs.get("dfa_windows", [(4, 11), (12, None)])
 
     # Determine max beats


### PR DESCRIPTION
# Description
This PR aims at fixing https://github.com/neuropsychology/NeuroKit/issues/1084 where if a signal has less than 12 rri, the short window for the HRV DFA computation fails. This pull suggests simply returning nan if we have less than 12 rri as the HRV DFA is not useful for short signals.

Please let me know what you think.