### PR TITLE
chore: make pywt an optional requirement

### DIFF
--- a/neurokit2/ecg/ecg_simulate.py
+++ b/neurokit2/ecg/ecg_simulate.py
@@ -4,7 +4,6 @@ import math
 import numpy as np
 import pandas as pd
 import scipy
-import pywt
 
 from ..misc import check_random_state, check_random_state_children
 from ..signal import signal_distort, signal_resample
@@ -207,6 +206,16 @@ def _ecg_simulate_daubechies(duration=10, length=None, sampling_rate=1000, heart
     This function is based on `this script <https://github.com/diarmaidocualain/ecg_simulation>`_.
 
     """
+    # Try loading pywt
+    try:
+        import pywt
+    except ImportError:
+        raise ImportError(
+            "NeuroKit error: ecg_simulate(): the 'PyWavelets' module is required for this",
+            "method to run. ",
+            "Please install it first (`pip install PyWavelets`).",
+        )
+    
     # The "Daubechies" wavelet is a rough approximation to a real, single, cardiac cycle
     cardiac = np.array(pywt.Wavelet("db10").rec_lo)
 

--- a/neurokit2/signal/signal_timefrequency.py
+++ b/neurokit2/signal/signal_timefrequency.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import matplotlib.pyplot as plt
 import numpy as np
-import pywt
 import scipy.signal
 
 from ..signal.signal_detrend import signal_detrend
@@ -293,6 +292,15 @@ def continuous_wt(
       Royal Society A: Mathematical, Physical and Engineering Sciences, 376(2126), 20170250.
 
     """
+    # Try loading pywt
+    try:
+        import pywt
+    except ImportError:
+        raise ImportError(
+            "NeuroKit error: signal_timefrequency(): the 'PyWavelets' module is required for this",
+            "method to run. ",
+            "Please install it first (`pip install PyWavelets`).",
+        )
 
     if nfreqbin is None:
         nfreqbin = sampling_rate // 2


### PR DESCRIPTION
# Description

This PR removes the hardcoded `import pywt` and throws `ImportError` when pywt is really needed.

This will fix the import error when pywavelets is not installed:

```
>>> import neurokit2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/app/.venv/lib/python3.10/site-packages/neurokit2/__init__.py", line 14, in <module>
    from .benchmark import *
  File "/app/.venv/lib/python3.10/site-packages/neurokit2/benchmark/__init__.py", line 3, in <module>
    from .benchmark_ecg import benchmark_ecg_preprocessing
  File "/app/.venv/lib/python3.10/site-packages/neurokit2/benchmark/benchmark_ecg.py", line 7, in <module>
    from ..signal import signal_period
  File "/app/.venv/lib/python3.10/site-packages/neurokit2/signal/__init__.py", line 30, in <module>
    from .signal_timefrequency import signal_timefrequency
  File "/app/.venv/lib/python3.10/site-packages/neurokit2/signal/signal_timefrequency.py", line 4, in <module>
    import pywt
ModuleNotFoundError: No module named 'pywt'
```

# Proposed Changes

Since `pywavelets` package is listed only in testing requirements, it is possible that nk2 does not need pywavelets to run. 

I changed two direct `import pywt` and move them in to the actual functions.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] ~~I have added the newly added features to **News.rst** (not applicable)~~
