### PR TITLE
Add Pywavelets to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def find_version():
 
 
 # Dependencies
-requirements = ["requests", "numpy", "pandas", "scipy", "scikit-learn>=1.0.0", "matplotlib>=3.5.0"]
+requirements = ["requests", "numpy", "pandas", "scipy", "scikit-learn>=1.0.0", "matplotlib>=3.5.0", "PyWavelets>=1.4.0"]
 
 # Optional Dependencies (only needed / downloaded for testing purposes, for instance to test against some other packages)
 setup_requirements = ["pytest-runner", "numpy"]
@@ -41,7 +41,7 @@ test_requirements = requirements + [
     "nolds",
     "biosppy==0.6.1",
     "cvxopt",
-    "PyWavelets",
+    "PyWavelets>=1.4.0",
     "EMD-signal",
     "numba>=0.61.0",
     "llvmlite>=0.44.0",


### PR DESCRIPTION
# Description

This PR adds Pywavelets to required dependency list.

# Proposed Changes

After the discussion in https://github.com/neuropsychology/NeuroKit/pull/1093, we agreed on adding Pywavelets to dependency list.

I also sets `PyWavelets>=1.4.0` because the function `pywt.frequency2scale()` (which is called in `signal/signal_timefrequency.py`) was added in this version.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- ~~[ ] I have added the newly added features to **News.rst** (not applicable)~~
