### PR TITLE
Fix rsp_amplitude type error

### DIFF
--- a/neurokit2/rsp/rsp_amplitude.py
+++ b/neurokit2/rsp/rsp_amplitude.py
@@ -6,9 +6,7 @@ from ..signal import signal_interpolate
 from .rsp_fixpeaks import _rsp_fixpeaks_retrieve
 
 
-def rsp_amplitude(
-    rsp_cleaned, peaks, troughs=None, method="standard", interpolation_method="monotone_cubic"
-):
+def rsp_amplitude(rsp_cleaned, peaks, troughs=None, method="standard", interpolation_method="monotone_cubic"):
     """**Compute respiratory amplitude**
 
     Compute respiratory amplitude given the raw respiration signal and its extrema. The
@@ -75,6 +73,9 @@ def rsp_amplitude(
       neurophysiology, 122(2), 849-861.
 
     """
+    # Make sure `rsp_cleaned` is a np.array
+    rsp_cleaned = np.array(rsp_cleaned)
+
     # Format input.
     peaks, troughs = _rsp_fixpeaks_retrieve(peaks, troughs)
 
@@ -104,8 +105,6 @@ def rsp_amplitude(
     if len(peaks) == 1:
         amplitude = np.full(rsp_cleaned.shape, amplitude[0])
     else:
-        amplitude = signal_interpolate(
-            peaks, amplitude, x_new=np.arange(len(rsp_cleaned)), method=interpolation_method
-        )
+        amplitude = signal_interpolate(peaks, amplitude, x_new=np.arange(len(rsp_cleaned)), method=interpolation_method)
 
     return amplitude

--- a/tests/tests_rsp.py
+++ b/tests/tests_rsp.py
@@ -201,6 +201,16 @@ def test_rsp_amplitude():
     assert amplitude.shape == (rsp.size,)
     assert np.abs(amplitude.mean() - 1) < 0.01
 
+    # Test with `rsp` as pd.Series
+    amplitude = nk.rsp_amplitude(pd.Series(rsp), info)
+    assert amplitude.shape == (pd.Series(rsp).size,)
+    assert np.abs(amplitude.mean() - 1) < 0.01
+
+    # Test with `rsp` as list
+    amplitude = nk.rsp_amplitude(rsp.tolist(), info)
+    assert amplitude.shape == (len(rsp.tolist()),)
+    assert np.abs(amplitude.mean() - 1) < 0.01
+
 
 def test_rsp_rav():
     rsp = nk.rsp_simulate(

--- a/tests/tests_rsp.py
+++ b/tests/tests_rsp.py
@@ -192,23 +192,23 @@ def test_rsp_amplitude():
     signals, info = nk.rsp_peaks(rsp_cleaned)
 
     # Test with dictionary.
-    amplitude = nk.rsp_amplitude(rsp, signals)
-    assert amplitude.shape == (rsp.size,)
+    amplitude = nk.rsp_amplitude(rsp_cleaned, signals)
+    assert amplitude.shape == (rsp_cleaned.size,)
     assert np.abs(amplitude.mean() - 1) < 0.01
 
     # Test with DataFrame.
-    amplitude = nk.rsp_amplitude(rsp, info)
-    assert amplitude.shape == (rsp.size,)
+    amplitude = nk.rsp_amplitude(rsp_cleaned, info)
+    assert amplitude.shape == (rsp_cleaned.size,)
     assert np.abs(amplitude.mean() - 1) < 0.01
 
     # Test with `rsp` as pd.Series
-    amplitude = nk.rsp_amplitude(pd.Series(rsp), info)
-    assert amplitude.shape == (pd.Series(rsp).size,)
+    amplitude = nk.rsp_amplitude(pd.Series(rsp_cleaned), info)
+    assert amplitude.shape == (pd.Series(rsp_cleaned).size,)
     assert np.abs(amplitude.mean() - 1) < 0.01
 
     # Test with `rsp` as list
-    amplitude = nk.rsp_amplitude(rsp.tolist(), info)
-    assert amplitude.shape == (len(rsp.tolist()),)
+    amplitude = nk.rsp_amplitude(rsp_cleaned.tolist(), info)
+    assert amplitude.shape == (len(rsp_cleaned.tolist()),)
     assert np.abs(amplitude.mean() - 1) < 0.01
 
 


### PR DESCRIPTION
# Description

closes #1101 

# Proposed Changes

I changed the rsp_amplitude function to better deal with different data type accepted for `rsp_cleaned` parameters (see #1101) 


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
