### PR TITLE
add msptdfastv2 PPG peak detector

### DIFF
--- a/neurokit2/ppg/ppg_findpeaks.py
+++ b/neurokit2/ppg/ppg_findpeaks.py
@@ -68,6 +68,8 @@ def ppg_findpeaks(
     * Bishop, S. M., & Ercole, A. (2018). Multi-scale peak and trough detection optimised for
       periodic and quasi-periodic neuroscience data. In Intracranial Pressure & Neuromonitoring XVI
       (pp. 189-195). Springer International Publishing.
+    * Charlton, P. H. et al. (2025). The MSPTDfast photoplethysmography beat detection algorithm:
+      design, benchmarking, and open-source distribution. Physiological Measurement, 46, 035002.
     * Charlton, P. H. et al. (2024). MSPTDfast: An Efficient Photoplethysmography Beat Detection
       Algorithm. Proc CinC.
 
@@ -77,8 +79,10 @@ def ppg_findpeaks(
         peaks = _ppg_findpeaks_elgendi(ppg_cleaned, sampling_rate, show=show, **kwargs)
     elif method in ["msptd", "bishop2018", "bishop"]:
         peaks, _ = _ppg_findpeaks_bishop(ppg_cleaned, show=show, **kwargs)
-    elif method in ["msptdfast", "msptdfastv1", "charlton2024", "charlton"]:
-        peaks, onsets = _ppg_findpeaks_charlton(ppg_cleaned, sampling_rate, show=show, **kwargs)
+    elif method in ["msptdfast", "msptdfastv2", "charlton2025", "charlton"]:
+        peaks, onsets = _ppg_findpeaks_charlton(ppg_cleaned, sampling_rate, win_durn=6, show=show, **kwargs)
+    elif method in ["msptdfastv1", "charlton2024"]:
+        peaks, onsets = _ppg_findpeaks_charlton(ppg_cleaned, sampling_rate, win_durn=8, show=show, **kwargs)
     else:
         raise ValueError(
             "`method` not found. Must be one of the following: 'elgendi', 'bishop', 'charlton'."
@@ -250,11 +254,15 @@ def _ppg_findpeaks_bishop(
 def _ppg_findpeaks_charlton(
     signal,
     sampling_rate=1000,
+    win_durn=6,
     show=False,
 ):
-    """Implementation of Charlton et al (2024) MSPTDfast: An Efficient Photoplethysmography
-    Beat Detection Algorithm. 2024 Computing in Cardiology (CinC), Karlsruhe, Germany,
-    doi:10.1101/2024.07.18.24310627.
+    """Implementation of MSPTDfastv2, as described in:
+    Charlton, P. H. et al. (2025). The MSPTDfast photoplethysmography beat detection algorithm: design, benchmarking,
+    and open-source distribution. Physiological Measurement, 46, 035002, doi:10.1088/1361-6579/adb89e
+
+    Also, when win_durn=8, this is an implementation of MSPTDfastv1, as described in:
+    Charlton, P. H. et al. (2024). MSPTDfast: An Efficient Photoplethysmography Beat Detection Algorithm. Proc CinC.
     """
 
     # Inner functions
@@ -383,7 +391,7 @@ def _ppg_findpeaks_charlton(
         return peaks, onsets
 
     # ~~~ Main function ~~~
-
+    
     # Specify settings
     # - version: optimal selection (CinC 2024)
     options = {
@@ -392,7 +400,7 @@ def _ppg_findpeaks_charlton(
         'do_ds': True,  # whether or not to do downsampling
         'ds_freq': 20,  # the target downsampling frequency
         'use_reduced_lms_scales': True,  # whether or not to reduce the number of scales (default 30 bpm)
-        'win_len': 8,  # duration of individual windows for analysis
+        'win_len': win_durn,  # duration of individual windows for analysis (8 secs for MSPTDfastv1; 6 secs for MSPTDfastv2)
         'win_overlap': 0.2,  # proportion of window overlap
         'plaus_hr_bpm': [30, 200]  # range of plausible HRs (only the lower bound is used)
     }

--- a/neurokit2/ppg/ppg_peaks.py
+++ b/neurokit2/ppg/ppg_peaks.py
@@ -33,8 +33,8 @@ def ppg_peaks(
     sampling_rate : int
         The sampling frequency of ``ppg_cleaned`` (in Hz, i.e., samples/second). Defaults to 1000.
     method : str
-        The processing pipeline to apply. Can be one of ``"elgendi"``, ``"bishop"``. The default is
-        ``"elgendi"``.
+        The processing pipeline to apply. Can be one of ``"elgendi"``, ``"bishop"``, ``"charlton"``.
+        The default is ``"elgendi"``.
     correct_artifacts : bool
         Whether or not to identify and fix artifacts, using the method by
         Lipponen & Tarvainen (2019).
@@ -95,6 +95,8 @@ def ppg_peaks(
     * Bishop, S. M., & Ercole, A. (2018). Multi-scale peak and trough detection optimised for
       periodic and quasi-periodic neuroscience data. In Intracranial Pressure & Neuromonitoring XVI
       (pp. 189-195). Springer International Publishing.
+    * Charlton, P. H. et al. (2025). The MSPTDfast photoplethysmography beat detection algorithm:
+      design, benchmarking, and open-source distribution. Physiological Measurement, 46, 035002.
 
     """
     # Store info


### PR DESCRIPTION
# Description

This PR aims at adding the MSPTDfastv2 PPG peak detection algorithm. This algorithm is a slight modification of MSPTDfast v1 algorithm, which is currently available in Neurokit.

# Proposed Changes

I changed `ppg_findpeaks.py` so that it includes both MSPTDfastv1 and MSPTDfastv2.
I changed `ppg_peaks.py` to provide an updated reference for MSPTDfastv2 (which supersedes the previous reference for MSPTDfastv1).

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)

# Notes

Note that this algorithm (as well as MSPTDfastv1) don't currently provide accurate beat detections because there are repeated detections between overlapping windows. This is to be expected, and is in keeping with the original algorithms. My next step will be to add the corresponding function to `signal_fixpeaks` to correct for this. This will be based on the `tidy_peaks_and_onsets` function originally provided in `[detect_ppg_beats.m](https://github.com/peterhcharlton/ppg-beats/blob/main/source/detect_ppg_beats.m)`.