### PR TITLE
Add ecg quality template matching method

### DIFF
--- a/neurokit2/ecg/ecg_quality.py
+++ b/neurokit2/ecg/ecg_quality.py
@@ -8,6 +8,7 @@ from ..epochs import epochs_to_df
 from ..misc import NeuroKitWarning
 from ..signal import signal_interpolate
 from ..signal.signal_power import signal_power
+from ..signal.signal_templatequality import signal_templatequality
 from ..stats import distance, rescale
 from .ecg_peaks import ecg_peaks
 from .ecg_segment import ecg_segment
@@ -19,6 +20,13 @@ def ecg_quality(
     """**ECG Signal Quality Assessment**
 
     Assess the quality of the ECG Signal using various methods:
+
+    * The ``"templatematch"`` method (loosely based on Orphanidou et al., 2015) computes a continuous
+      index of quality of the ECG signal, by calculating the correlation coefficient between each
+      individual beat morphology and an average (template) beat morphology. This index is therefore
+      relative: 1 corresponds to individual beats that are closest to the beat morphology (i.e.
+      correlate exactly with it) and 0 corresponds to there being no correlation with the average
+      beat morphology.
 
     * The ``"averageQRS"`` method computes a continuous index of quality of the ECG signal, by
       interpolating the distance of each QRS segment from the average QRS segment present in the *
@@ -62,13 +70,15 @@ def ecg_quality(
 
     See Also
     --------
-    ecg_segment, ecg_delineate
+    ecg_segment, ecg_delineate, signal_templatequality
 
     References
     ----------
     * Zhao, Z., & Zhang, Y. (2018). "SQI quality evaluation mechanism of single-lead ECG signal
       based on simple heuristic fusion and fuzzy comprehensive evaluation". Frontiers in
       Physiology, 9, 727.
+    * Orphanidou, C. et al. (2015). "Signal-quality indices for the electrocardiogram and photoplethysmogram:
+      derivation and applications to wireless monitoring". IEEE Journal of Biomedical and Health Informatics, 19(3), 832-8.
 
     Examples
     --------
@@ -100,7 +110,7 @@ def ecg_quality(
 
     method = method.lower()  # remove capitalised letters
 
-    # Run peak detection algorithm
+    # Run quality assessment algorithm
     if method in ["averageqrs"]:
         quality = _ecg_quality_averageQRS(
             ecg_cleaned, rpeaks=rpeaks, sampling_rate=sampling_rate
@@ -119,6 +129,15 @@ def ecg_quality(
         quality = _ecg_quality_zhao2018(
             ecg_cleaned, rpeaks=rpeaks, sampling_rate=sampling_rate, mode=approach
         )
+    elif method in ["templatematch", "orphanidou2015"]:
+        # Detect R peaks (if not done already)
+        if rpeaks is None:
+            _, rpeaks = ecg_peaks(ecg_cleaned, sampling_rate=sampling_rate)
+            rpeaks = rpeaks["ECG_R_Peaks"]
+        # Assess quality using template matching
+        quality = signal_templatequality(
+            ecg_cleaned, beat_inds=rpeaks, signal_type='ecg', sampling_rate=sampling_rate, method='templatematch'
+        )    
 
     return quality
 

--- a/neurokit2/ppg/ppg_process.py
+++ b/neurokit2/ppg/ppg_process.py
@@ -102,7 +102,7 @@ def ppg_process(
     # Assess signal quality
     quality = ppg_quality(
         ppg_cleaned,
-        ppg_pw_peaks=info["PPG_Peaks"],
+        peaks=info["PPG_Peaks"],
         sampling_rate=sampling_rate,
         method=methods["method_quality"],
         **methods["kwargs_quality"]

--- a/neurokit2/ppg/ppg_quality.py
+++ b/neurokit2/ppg/ppg_quality.py
@@ -2,11 +2,12 @@
 
 import numpy as np
 
+from .ppg_peaks import ppg_peaks
 from ..signal.signal_templatequality import signal_templatequality
 
 
 def ppg_quality(
-    ppg_cleaned, peaks=None, sampling_rate=1000, method="templatematch", approach=None
+    ppg_cleaned, peaks=None, sampling_rate=1000, method="templatematch"
 ):
     """**PPG Signal Quality Assessment**
 
@@ -47,12 +48,14 @@ def ppg_quality(
 
     See Also
     --------
-    ppg_segment
+    signal_templatequality
 
     References
     ----------
     * Orphanidou, C. et al. (2015). "Signal-quality indices for the electrocardiogram and photoplethysmogram:
       derivation and applications to wireless monitoring". IEEE Journal of Biomedical and Health Informatics, 19(3), 832-8.
+    * Sabeti E. et al. (2019). Signal quality measure for pulsatile physiological signals using morphological features: 
+      Applications in reliability measure for pulse oximetry. Informatics in Medicine Unlocked, 16, 100222.
 
     Examples
     --------
@@ -77,15 +80,15 @@ def ppg_quality(
 
     # Detect PPG peaks (if not done already)
     if peaks is None:
-        _, peaks = peaks(ppg_cleaned, sampling_rate=sampling_rate)
-        peaks = peaks["peaks"]
+        _, peaks = ppg_peaks(ppg_cleaned, sampling_rate=sampling_rate)
+        peaks = peaks["PPG_Peaks"]
 
     # Run selected quality assessment method
-    if method in ["templatematch"]:
+    if method in ["templatematch", "orphanidou2015"]:
         quality = signal_templatequality(
             ppg_cleaned, beat_inds=peaks, signal_type='ppg', sampling_rate=sampling_rate, method='templatematch'
         )
-    elif method in ["disimilarity"]:
+    elif method in ["disimilarity", "sabeti2019"]:
         quality = signal_templatequality(
             ppg_cleaned, beat_inds=peaks, signal_type = 'ppg', sampling_rate=sampling_rate, method='disimilarity'
         )

--- a/neurokit2/ppg/ppg_quality.py
+++ b/neurokit2/ppg/ppg_quality.py
@@ -2,14 +2,11 @@
 
 import numpy as np
 
-from ..epochs import epochs_to_df
-from ..signal import signal_interpolate
-from .ppg_peaks import ppg_peaks
-from .ppg_segment import ppg_segment
+from ..signal.signal_templatequality import signal_templatequality
 
 
 def ppg_quality(
-    ppg_cleaned, ppg_pw_peaks=None, sampling_rate=1000, method="templatematch", approach=None
+    ppg_cleaned, peaks=None, sampling_rate=1000, method="templatematch", approach=None
 ):
     """**PPG Signal Quality Assessment**
 
@@ -20,8 +17,7 @@ def ppg_quality(
       individual pulse wave and an average (template) pulse wave shape. This index is therefore
       relative: 1 corresponds to pulse waves that are closest to the average pulse wave shape (i.e.
       correlate exactly with it) and 0 corresponds to there being no correlation with the average
-      pulse wave shape. Note that 1 does not necessarily mean "good": use this index with care and
-      plot it alongside your PPG signal to see if it makes sense.
+      pulse wave shape.
 
     * The ``"disimilarity"`` method (loosely based on Sabeti et al., 2019) computes a continuous index
       of quality of the PPG signal, by calculating the level of disimilarity between each individual 
@@ -35,7 +31,7 @@ def ppg_quality(
     ----------
     ppg_cleaned : Union[list, np.array, pd.Series]
         The cleaned PPG signal in the form of a vector of values.
-    ppg_pw_peaks : tuple or list
+    peaks : tuple or list
         The list of PPG pulse wave peak samples returned by ``ppg_peaks()``. If None, peaks is computed from
         the signal input.
     sampling_rate : int
@@ -45,7 +41,7 @@ def ppg_quality(
 
     Returns
     -------
-    array
+    quality : array
         Vector containing the quality index ranging from 0 to 1 for ``"templatematch"`` method,
         or an unbounded value (where 0 indicates high quality) for ``"disimilarity"`` method.
 
@@ -79,118 +75,19 @@ def ppg_quality(
 
     method = method.lower()  # remove capitalised letters
 
+    # Detect PPG peaks (if not done already)
+    if peaks is None:
+        _, peaks = peaks(ppg_cleaned, sampling_rate=sampling_rate)
+        peaks = peaks["peaks"]
+
     # Run selected quality assessment method
     if method in ["templatematch"]:
-        quality = _ppg_quality_templatematch(
-            ppg_cleaned, ppg_pw_peaks=ppg_pw_peaks, sampling_rate=sampling_rate
+        quality = signal_templatequality(
+            ppg_cleaned, beat_inds=peaks, signal_type='ppg', sampling_rate=sampling_rate, method='templatematch'
         )
     elif method in ["disimilarity"]:
-        quality = _ppg_quality_disimilarity(
-            ppg_cleaned, ppg_pw_peaks=ppg_pw_peaks, sampling_rate=sampling_rate
+        quality = signal_templatequality(
+            ppg_cleaned, beat_inds=peaks, signal_type = 'ppg', sampling_rate=sampling_rate, method='disimilarity'
         )
-
-    return quality
-
-# =============================================================================
-# Calculate a template pulse wave
-# =============================================================================
-def _calc_template_pw(ppg_cleaned, ppg_pw_peaks=None, sampling_rate=1000):
-
-    # Sanitize inputs
-    if ppg_pw_peaks is None:
-        _, ppg_pw_peaks = ppg_peaks(ppg_cleaned, sampling_rate=sampling_rate)
-        ppg_pw_peaks = ppg_pw_peaks["PPG_Peaks"]
-
-    # Get heartbeats
-    heartbeats = ppg_segment(ppg_cleaned, ppg_pw_peaks, sampling_rate)
-    pw_data = epochs_to_df(heartbeats).pivot(
-        index="Label", columns="Time", values="Signal"
-    )
-    pw_data.index = pw_data.index.astype(int)
-    pw_data = pw_data.sort_index()
-
-    # Filter Nans
-    missing = pw_data.T.isnull().sum().values
-    nonmissing = np.where(missing == 0)[0]
-    pw_data = pw_data.iloc[nonmissing, :]
-
-    # Find template pulse wave
-    templ_pw = pw_data.mean()
-
-    return templ_pw, pw_data, ppg_pw_peaks
-
-
-# =============================================================================
-# Template-matching method
-# =============================================================================
-def _ppg_quality_templatematch(ppg_cleaned, ppg_pw_peaks=None, sampling_rate=1000):
-
-    # Obtain individual pulse waves and template pulse wave
-    templ_pw, pw_data, ppg_pw_peaks = _calc_template_pw(
-            ppg_cleaned, ppg_pw_peaks=ppg_pw_peaks, sampling_rate=sampling_rate
-        )
-    
-    # Find individual correlation coefficients (CCs)
-    cc = np.zeros(len(ppg_pw_peaks)-1)
-    for beat_no in range(0,len(ppg_pw_peaks)-1):
-        temp = np.corrcoef(pw_data.iloc[beat_no], templ_pw)
-        cc[beat_no] = temp[0,1]
-
-    # Interpolate beat-by-beat CCs
-    quality = signal_interpolate(
-        ppg_pw_peaks[0:-1], cc, x_new=np.arange(len(ppg_cleaned)), method="previous"
-    )
-
-    return quality
-
-# =============================================================================
-# Disimilarity measure method
-# =============================================================================
-def _norm_sum_one(pw):
-
-    # ensure all values are positive
-    pw = pw - pw.min() + 1
-
-    # normalise pulse wave to sum to one
-    pw = [x / sum(pw) for x in pw]
-
-    return pw
-
-def _calc_dis(pw1, pw2):
-    # following the methodology in https://doi.org/10.1016/j.imu.2019.100222 (Sec. 3.1.2.5)
-
-    # convert to numpy arrays
-    pw1 = np.array(pw1)
-    pw2 = np.array(pw2)
-
-    # normalise to sum to one
-    pw1 = _norm_sum_one(pw1)
-    pw2 = _norm_sum_one(pw2)
-    
-    # ignore any elements which are zero because log(0) is -inf
-    rel_els = (pw1 != 0) & (pw2 != 0)
-
-    # calculate disimilarity measure (using pw2 as the template)
-    dis = np.sum(pw2[rel_els] * np.log(pw2[rel_els] / pw1[rel_els]))
-
-    return dis
-
-
-def _ppg_quality_disimilarity(ppg_cleaned, ppg_pw_peaks=None, sampling_rate=1000):
-
-    # Obtain individual pulse waves and template pulse wave
-    templ_pw, pw_data, ppg_pw_peaks = _calc_template_pw(
-            ppg_cleaned, ppg_pw_peaks=ppg_pw_peaks, sampling_rate=sampling_rate
-        )
-    
-    # Find individual disimilarity measures
-    dis = np.zeros(len(ppg_pw_peaks)-1)
-    for beat_no in range(0,len(ppg_pw_peaks)-1):
-        dis[beat_no] = _calc_dis(pw_data.iloc[beat_no], templ_pw)
-
-    # Interpolate beat-by-beat dis's
-    quality = signal_interpolate(
-        ppg_pw_peaks[0:-1], dis, x_new=np.arange(len(ppg_cleaned)), method="previous"
-    )
 
     return quality

--- a/neurokit2/ppg/ppg_quality.py
+++ b/neurokit2/ppg/ppg_quality.py
@@ -1,7 +1,5 @@
 # - * - coding: utf-8 - * -
 
-import numpy as np
-
 from .ppg_peaks import ppg_peaks
 from ..signal.signal_templatequality import signal_templatequality
 

--- a/neurokit2/signal/__init__.py
+++ b/neurokit2/signal/__init__.py
@@ -27,6 +27,7 @@ from .signal_simulate import signal_simulate
 from .signal_smooth import signal_smooth
 from .signal_surrogate import signal_surrogate
 from .signal_synchrony import signal_synchrony
+from .signal_templatequality import signal_templatequality
 from .signal_timefrequency import signal_timefrequency
 from .signal_zerocrossings import signal_zerocrossings
 
@@ -57,6 +58,7 @@ __all__ = [
     "signal_decompose",
     "signal_recompose",
     "signal_surrogate",
+    "signal_templatequality",
     "signal_timefrequency",
     "signal_sanitize",
     "signal_flatline",

--- a/neurokit2/signal/__init__.py
+++ b/neurokit2/signal/__init__.py
@@ -2,6 +2,7 @@
 from .signal_autocor import signal_autocor
 from .signal_binarize import signal_binarize
 from .signal_changepoints import signal_changepoints
+from .signal_cyclesegment import signal_cyclesegment
 from .signal_decompose import signal_decompose
 from .signal_detrend import signal_detrend
 from .signal_distort import signal_distort
@@ -34,6 +35,7 @@ from .signal_zerocrossings import signal_zerocrossings
 __all__ = [
     "signal_simulate",
     "signal_binarize",
+    "signal_cyclesegment",
     "signal_resample",
     "signal_zerocrossings",
     "signal_smooth",

--- a/neurokit2/signal/signal_cyclesegment.py
+++ b/neurokit2/signal/signal_cyclesegment.py
@@ -1,0 +1,100 @@
+# - * - coding: utf-8 - * -
+import numpy as np
+import pandas as pd
+
+from ..epochs import epochs_create
+from ..signal.signal_rate import signal_rate
+
+def signal_cyclesegment(signal_cleaned, cycle_indices, sampling_rate=1000, **kwargs):
+    """**Segment a signal into individual cycles**
+
+    Segment a signal (e.g. ECG, PPG, respiratory) into individual cycles (e.g. heartbeats, pulse waves, breaths).
+
+    Parameters
+    ----------
+    signal_cleaned : Union[list, np.array, pd.Series]
+        The cleaned signal channel, such as that returned by ``ppg_clean()`` or ``ecg_clean()``.
+    cycle_indices : dict
+        The samples indicating individual cycles (such as PPG peaks or ECG R-peaks), such as a dict
+        returned by ``ppg_peaks()``.
+    sampling_rate : int
+        The sampling frequency of ``signal_cleaned`` (in Hz, i.e., samples/second). Defaults to 1000.
+    **kwargs
+        Other arguments to be passed.
+
+    Returns
+    -------
+    dict
+        A dict containing DataFrames for all segmented cycles.
+
+    See Also
+    --------
+    ppg_clean, ecg_clean, ppg_peaks, ecg_peaks, ppg_quality, ecg_quality
+
+    Examples
+    --------
+    .. ipython:: python
+
+      import neurokit2 as nk
+
+      ppg = nk.ppg_simulate(duration=30, sampling_rate=100, heart_rate=80)
+      @savefig p_ppg_segment.png scale=100%
+      ppg_epochs = nk.ppg_segment(ppg, sampling_rate=100, show=True)
+      @suppress
+      plt.close()
+
+    """
+
+    # To-do: This doesn't currently contain the plotting functionality of ecg_segment.
+
+    if len(signal_cleaned) < sampling_rate * 4:
+        raise ValueError("The data length is too small to be segmented.")
+
+    epochs_start, epochs_end, average_cycle_rate = _segment_window(
+        cycle_indices=cycle_indices,
+        sampling_rate=sampling_rate,
+        desired_length=len(signal_cleaned),
+        ratio_pre=0.5,
+    )
+    cycles = epochs_create(
+        signal_cleaned,
+        cycle_indices,
+        sampling_rate=sampling_rate,
+        epochs_start=epochs_start,
+        epochs_end=epochs_end,
+    )
+
+    # pad last heartbeat with nan so that segments are equal length
+    last_cycle_key = str(np.max(np.array(list(cycles.keys()), dtype=int)))
+    after_last_index = cycles[last_cycle_key]["Index"] < len(signal_cleaned)
+    cycles[last_cycle_key].loc[after_last_index, "Signal"] = np.nan
+
+    return cycles
+
+
+def _segment_window(
+    cycle_rate=None,
+    cycle_indices=None,
+    sampling_rate=1000,
+    desired_length=None,
+    ratio_pre=0.5,
+):
+    # Extract cycle rate
+    if cycle_rate is not None:
+        cycle_rate = np.mean(cycle_rate)
+    if cycle_indices is not None:
+        cycle_rate = np.mean(
+            signal_rate(
+                cycle_indices, sampling_rate=sampling_rate, desired_length=desired_length
+            )
+        )
+    
+    # Modulator
+    # Note: this is based on quick internal testing but could be improved
+    window_size = 60 / cycle_rate  # Cycles per second
+
+    # Window
+    epochs_start = ratio_pre * window_size
+    epochs_end = (1 - ratio_pre) * window_size
+
+    return -epochs_start, epochs_end, cycle_rate

--- a/neurokit2/signal/signal_cyclesegment.py
+++ b/neurokit2/signal/signal_cyclesegment.py
@@ -36,12 +36,13 @@ def signal_cyclesegment(signal_cleaned, cycle_indices, sampling_rate=1000, **kwa
     .. ipython:: python
 
       import neurokit2 as nk
-
-      ppg = nk.ppg_simulate(duration=30, sampling_rate=100, heart_rate=80)
-      @savefig p_ppg_segment.png scale=100%
-      ppg_epochs = nk.ppg_segment(ppg, sampling_rate=100, show=True)
-      @suppress
-      plt.close()
+      
+      sampling_rate = 100
+      ppg = nk.ppg_simulate(duration=30, sampling_rate=sampling_rate, heart_rate=80)
+      ppg_cleaned = nk.ppg_clean(ppg, sampling_rate=sampling_rate)
+      _, peaks = ppg_peaks(ppg_cleaned, sampling_rate=sampling_rate)
+      peaks = peaks["PPG_Peaks"]
+      heartbeats = signal_cyclesegment(ppg_cleaned, peaks, sampling_rate=sampling_rate)
 
     """
 
@@ -64,7 +65,7 @@ def signal_cyclesegment(signal_cleaned, cycle_indices, sampling_rate=1000, **kwa
         epochs_end=epochs_end,
     )
 
-    # pad last heartbeat with nan so that segments are equal length
+    # pad last cycle with nan so that segments are equal length
     last_cycle_key = str(np.max(np.array(list(cycles.keys()), dtype=int)))
     after_last_index = cycles[last_cycle_key]["Index"] < len(signal_cleaned)
     cycles[last_cycle_key].loc[after_last_index, "Signal"] = np.nan

--- a/neurokit2/signal/signal_cyclesegment.py
+++ b/neurokit2/signal/signal_cyclesegment.py
@@ -1,6 +1,5 @@
 # - * - coding: utf-8 - * -
 import numpy as np
-import pandas as pd
 
 from ..epochs import epochs_create
 from ..signal.signal_rate import signal_rate

--- a/neurokit2/signal/signal_templatequality.py
+++ b/neurokit2/signal/signal_templatequality.py
@@ -13,7 +13,21 @@ def signal_templatequality(signal, beat_inds, signal_type, sampling_rate=1000, m
 
     Assess the quality of a signal (e.g. PPG or ECG) using the specified method. You can pass an unfiltered
     signal as an input, but typically a filtered signal (e.g. cleaned using ``ppg_clean()`` or ``ecg_clean()``) will result in
-    more reliable results.
+    more reliable results. The following methods are available:
+
+    * The ``"templatematch"`` method (loosely based on Orphanidou et al., 2015) computes a continuous
+      index of quality of the PPG or ECG signal, by calculating the correlation coefficient between each
+      individual beat's morphology and an average (template) beat morphology. This index is therefore
+      relative: 1 corresponds to a signal where each individual beat's morphology is closest to the average beat morphology
+      (i.e. correlate exactly with it) and 0 corresponds to there being no correlation with the average beat morphology.
+
+    * The ``"disimilarity"`` method (loosely based on Sabeti et al., 2019) computes a continuous index
+      of quality of the PPG or ECG signal, by calculating the level of disimilarity between each individual 
+      beat's morphology and an average (template) beat morpholoy (after they are normalised). A value of
+      zero indicates no disimilarity (i.e. equivalent beat morphologies), whereas values above or below
+      indicate increasing disimilarity. The original method used dynamic time-warping to align the pulse
+      waves prior to calculating the level of dsimilarity, whereas this implementation does not currently
+      include this step.
 
 
     Parameters

--- a/neurokit2/signal/signal_templatequality.py
+++ b/neurokit2/signal/signal_templatequality.py
@@ -1,0 +1,171 @@
+# - * - coding: utf-8 - * -
+import numpy as np
+import pandas as pd
+
+from ..epochs import epochs_to_df
+from ..ppg.ppg_segment import ppg_segment
+from ..ecg.ecg_segment import ecg_segment
+from ..signal import signal_interpolate
+
+
+def signal_templatequality(signal, beat_inds, signal_type, sampling_rate=1000, method="templatematch"):
+    """**Assess quality of signal by comparing individual beat morphologies with a template**
+
+    Assess the quality of a signal (e.g. PPG or ECG) using the specified method. You can pass an unfiltered
+    signal as an input, but typically a filtered signal (e.g. cleaned using ``ppg_clean()`` or ``ecg_clean()``) will result in
+    more reliable results.
+
+
+    Parameters
+    ----------
+    signal : Union[list, np.array, pd.Series]
+        The cleaned signal, such as that returned by ``ppg_clean()`` or ``ecg_clean()``.
+    beat_inds : tuple or list
+        The list of beat samples (e.g. PPG or ECG peaks returned by ``ppg_peaks()`` or ``ecg_peaks()``).
+    signal_type : str
+        The signal type (e.g. 'ppg' or 'ecg').
+    sampling_rate : int
+        The sampling frequency of ``signal`` (in Hz, i.e., samples/second). Defaults to 1000.
+    method : str
+        The processing pipeline to apply. Can be one of ``"disimilarity"``, ``"templatematch"``. The default is
+        ``"templatematch"``.
+    **kwargs
+        Additional keyword arguments, usually specific for each method.
+
+    Returns
+    -------
+    quality : array
+        Vector containing the quality index ranging from 0 to 1 for ``"templatematch"`` method,
+        or an unbounded value (where 0 indicates high quality) for ``"disimilarity"`` method.
+
+    See Also
+    --------
+    ppg_quality
+
+    References
+    ----------
+    * Orphanidou, C. et al. (2015). "Signal-quality indices for the electrocardiogram and photoplethysmogram:
+      derivation and applications to wireless monitoring". IEEE Journal of Biomedical and Health Informatics, 19(3), 832-8.
+    * Sabeti E. et al. (2019). Signal quality measure for pulsatile physiological signals using morphological features: 
+      Applications in reliability measure for pulse oximetry. Informatics in Medicine Unlocked, 16, 100222.
+    """
+
+    signal_type = signal_type.lower()  # remove capitalised letters
+
+    # Run selected quality assessment method
+    if method in ["templatematch"]:  # Based on the approach in Orphanidou et al. (2015)
+        quality = _quality_templatematch(
+            signal, beat_inds=beat_inds, signal_type=signal_type, sampling_rate=sampling_rate,
+        )
+    elif method in ["disimilarity"]:  # Based on the approach in Sabeti et al. (2019)
+        quality = _quality_disimilarity(
+            signal, beat_inds=beat_inds, signal_type=signal_type, sampling_rate=sampling_rate
+        )
+
+    return quality
+
+# =============================================================================
+# Calculate template morphology
+# =============================================================================
+def _calc_template_morph(signal, beat_inds, signal_type, sampling_rate=1000):
+
+    # Segment to get individual beat morphologies
+    if signal_type == 'ppg':
+        heartbeats = ppg_segment(signal, beat_inds, sampling_rate)
+    elif signal_type == 'ecg':
+        heartbeats = ecg_segment(signal, beat_inds, sampling_rate)
+
+    # convert these to dataframe
+    ind_morph = epochs_to_df(heartbeats).pivot(
+        index="Label", columns="Time", values="Signal"
+    )
+    ind_morph.index = ind_morph.index.astype(int)
+    ind_morph = ind_morph.sort_index()
+
+    # Filter Nans
+    missing = ind_morph.T.isnull().sum().values
+    nonmissing = np.where(missing == 0)[0]
+    ind_morph = ind_morph.iloc[nonmissing, :]
+
+    # Find template pulse wave as the average pulse wave shape
+    templ_pw = ind_morph.mean()
+
+    return templ_pw, ind_morph, beat_inds
+
+
+# =============================================================================
+# Quality assessment using template-matching method
+# =============================================================================
+def _quality_templatematch(signal, beat_inds=None, signal_type='ppg', sampling_rate=1000):
+
+    # Obtain individual beat morphologies and template beat morphology
+    templ_morph, ind_morph, beat_inds = _calc_template_morph(
+            signal, beat_inds=beat_inds, signal_type=signal_type, sampling_rate=sampling_rate
+        )
+    
+    # Find correlation coefficients (CCs) between individual beat morphologies and the template
+    cc = np.zeros(len(beat_inds)-1)
+    for beat_no in range(0,len(beat_inds)-1):
+        temp = np.corrcoef(ind_morph.iloc[beat_no], templ_morph)
+        cc[beat_no] = temp[0,1]
+
+    # Interpolate beat-by-beat CCs
+    quality = signal_interpolate(
+        beat_inds[0:-1], cc, x_new=np.arange(len(signal)), method="previous"
+    )
+
+    return quality
+
+# =============================================================================
+# Disimilarity measure method
+# =============================================================================
+def _norm_sum_one(pw):
+
+    # ensure all values are positive
+    pw = pw - pw.min() + 1
+
+    # normalise pulse wave to sum to one
+    pw = [x / sum(pw) for x in pw]
+
+    return pw
+
+def _calc_dis(pw1, pw2):
+    # following the methodology in https://doi.org/10.1016/j.imu.2019.100222 (Sec. 3.1.2.5)
+
+    # convert to numpy arrays
+    pw1 = np.array(pw1)
+    pw2 = np.array(pw2)
+
+    # normalise to sum to one
+    pw1 = _norm_sum_one(pw1)
+    pw2 = _norm_sum_one(pw2)
+    
+    # ignore any elements which are zero because log(0) is -inf
+    rel_els = (pw1 != 0) & (pw2 != 0)
+
+    # calculate disimilarity measure (using pw2 as the template)
+    dis = np.sum(pw2[rel_els] * np.log(pw2[rel_els] / pw1[rel_els]))
+
+    return dis
+
+# =============================================================================
+# Quality assessment using disimilarity method
+# =============================================================================
+def _quality_disimilarity(signal, beat_inds=None, signal_type='ppg', sampling_rate=1000):
+
+    # Obtain individual beat morphologies and template beat morphology
+    templ_morph, ind_morph, beat_inds = _calc_template_morph(
+            signal, beat_inds=beat_inds, signal_type=signal_type, sampling_rate=sampling_rate
+        )
+    
+    # Find individual disimilarity measures
+    dis = np.zeros(len(beat_inds)-1)
+    for beat_no in range(0,len(beat_inds)-1):
+        dis[beat_no] = _calc_dis(ind_morph.iloc[beat_no], templ_morph)
+
+    # Interpolate beat-by-beat dis's
+    quality = signal_interpolate(
+        beat_inds[0:-1], dis, x_new=np.arange(len(signal)), method="previous"
+    )
+
+    return quality

--- a/neurokit2/signal/signal_templatequality.py
+++ b/neurokit2/signal/signal_templatequality.py
@@ -1,6 +1,5 @@
 # - * - coding: utf-8 - * -
 import numpy as np
-import pandas as pd
 
 from ..epochs import epochs_to_df
 from ..signal import signal_interpolate, signal_cyclesegment

--- a/neurokit2/signal/signal_templatequality.py
+++ b/neurokit2/signal/signal_templatequality.py
@@ -3,9 +3,7 @@ import numpy as np
 import pandas as pd
 
 from ..epochs import epochs_to_df
-from ..ppg.ppg_segment import ppg_segment
-from ..ecg.ecg_segment import ecg_segment
-from ..signal import signal_interpolate
+from ..signal import signal_interpolate, signal_cyclesegment
 
 
 def signal_templatequality(signal, beat_inds, signal_type, sampling_rate=1000, method="templatematch"):
@@ -85,9 +83,9 @@ def _calc_template_morph(signal, beat_inds, signal_type, sampling_rate=1000):
 
     # Segment to get individual beat morphologies
     if signal_type == 'ppg':
-        heartbeats = ppg_segment(signal, beat_inds, sampling_rate)
+        heartbeats = signal_cyclesegment(signal, beat_inds, sampling_rate)
     elif signal_type == 'ecg':
-        heartbeats = ecg_segment(signal, beat_inds, sampling_rate)
+        heartbeats = signal_cyclesegment(signal, beat_inds, sampling_rate)
 
     # convert these to dataframe
     ind_morph = epochs_to_df(heartbeats).pivot(


### PR DESCRIPTION
# Description

This PR aims at adding the "template matching" method to `ecg_quality()`. In doing so, I created a couple of generic signal functions.

# Proposed Changes

- I created a generic `signal_cyclesegment()` function to segment a signal into individual cycles (e.g. to segment an ECG signal into individual heartbeats.
- I created a generic `signal_templatequality()` function to perform template matching quality assessment (create an average cycle template, and then compare individual cycles with this template).
- I updated `ppg_quality()` to use the new `signal_templatequality()` function.
- I updated the `ecg_quality()` to incorporate template matching ECG quality assessment.


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [X] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [X] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
