### PR TITLE
[Fix] Fixed dead links

### DIFF
--- a/docs/resources/resources.rst
+++ b/docs/resources/resources.rst
@@ -9,7 +9,7 @@ General Neuroimaging
 -----------------------
 
 - `Seven quick tips for analysis scripts in neuroimaging <https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1007358>`_
-- `Neuroimaging tutorials and resources <https://.github.io/tutorials-and-resources/>`_
+- `Hitchhacker's guide to the brain <https://learn-neuroimaging.github.io/hitchhackers_guide_brain>`_
 
 
 
@@ -37,5 +37,5 @@ EDA
 EEG
 ----
 
-- `Electroencephalogram (EEG) Recording Protocol (Farrens et al., 2019) <https://protocolexchange.researchsquare.com/article/pex-779/v2>`_
+- `Electroencephalogram (EEG) Recording Protocol (Farrens et al., 2020) <https://www.protocols.io/view/electroencephalogram-eeg-recording-protocol-for-co-yxmvm9pk5l3p>`_
 - `Compute the average bandpower of an EEG signal <https://raphaelvallat.com/bandpower.html>`_


### PR DESCRIPTION
# Description

This PR aims to fix some dead links as mentionned in #1108 .

# Proposed Changes
Two links were dead :

- Neuroimaging tutorials and resources <https://.github.io/tutorials-and-resources/> is completly dead.
- Electroencephalogram (EEG) Recording Protocol (Farrens et al., 2019) <https://protocolexchange.researchsquare.com/article/pex-779/v2>_ links to https://www.protocols.io/ home's page.

The first one is the Github IO page of this repository I believe : https://github.com/DimitraMoraiti/tutorials-and-resources.
It has been moved to this repository : https://github.com/learn-neuroimaging/hitchhackers_guide_brain that links to this page : https://learn-neuroimaging.github.io/hitchhackers_guide_brain/. The last link is what I believe is the correct link.

For the second one, I searched the reference on the new website, giving me this link : https://www.protocols.io/view/electroencephalogram-eeg-recording-protocol-for-co-yxmvm9pk5l3p

I'm no expert, so I can't vouch if the links are correct or of good quality, but I believe that should be the expected ones.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [X] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [X] My PR is targeted at the **dev branch** (and not towards the master branch).
~- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.~
~- [ ] I have added the newly added features to **News.rst** (if applicable)~
