### PR TITLE
fix Divide by zero error in signal_fixpeaks #1116

### DIFF
--- a/neurokit2/signal/signal_fixpeaks.py
+++ b/neurokit2/signal/signal_fixpeaks.py
@@ -263,21 +263,26 @@ def _find_artifacts(
     rr = np.ediff1d(peaks, to_begin=0) / sampling_rate
     # For subsequent analysis it is important that the first element has
     # a value in a realistic range (e.g., for median filtering).
-    rr[0] = np.mean(rr[1:])
+    if len(rr) > 1:
+        rr[0] = np.mean(rr[1:])
+    else:
+        # Handle the case when there's only one peak
+        rr[0] = 1.0  # Default to 1 second interval
 
     # Artifact identification #################################################
     ###########################################################################
 
     # Compute dRRs: time series of differences of consecutive periods (dRRs).
     drrs = np.ediff1d(rr, to_begin=0)
-    drrs[0] = np.mean(drrs[1:])
+    if len(drrs) > 1:
+        drrs[0] = np.mean(drrs[1:])
+    else:
+        # Handle the case when there's only one element
+        drrs[0] = 0.0  # Default to 0 for single element case
     # Normalize by threshold.
     th1 = _compute_threshold(drrs, alpha, window_width)
-    # ignore division by 0 warning
-    old_setting = np.seterr(divide="ignore", invalid="ignore")
-    drrs /= th1
-    # return old setting
-    np.seterr(**old_setting)
+    np.divide(drrs, th1, out=drrs, where=th1 != 0)
+    drrs[th1 == 0] = np.nan
 
     # Cast dRRs to subspace s12.
     # Pad drrs with one element.
@@ -304,7 +309,8 @@ def _find_artifacts(
     mrrs[mrrs < 0] = mrrs[mrrs < 0] * 2
     # Normalize by threshold.
     th2 = _compute_threshold(mrrs, alpha, window_width)
-    mrrs /= th2
+    np.divide(mrrs, th2, out=mrrs, where=th2 != 0)
+    mrrs[th2 == 0] = np.nan
 
     # Artifact classification #################################################
     ###########################################################################


### PR DESCRIPTION
# Description

Fixed #1116 

# Proposed Changes

**Handled divide-by-zero safely**
- Replaced `mrrs /= th2` with `np.divide(mrrs, th2, out=mrrs, where=th2 != 0)`
- Added `mrrs[th2 == 0] = np.nan`
- Same changes applied to `drrs` and `th1`

**Fixed edge cases for single peaks**
- If `len(rr) > 1`, set `rr[0] = np.mean(rr[1:])`
- Applied the same check for `drrs`

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
