### PR TITLE
Resolve nonsquare qpeaks

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,12 @@
 News
 =====
 
+-------------------
+Fixes
++++++++++++++
+
+* Resolved ecg_delineate returning fewer qpeak indices than provided rpeaks when qpeak index was 0.
+
 0.2.8
 -------------------
 New Features

--- a/neurokit2/ecg/ecg_delineate.py
+++ b/neurokit2/ecg/ecg_delineate.py
@@ -205,7 +205,7 @@ def ecg_delineate(
 
     waves_sanitized = {}
     for feature, values in waves.items():
-        waves_sanitized[feature] = [x for x in values if x > 0 or x is np.nan]
+        waves_sanitized[feature] = [x if x > 0 else np.nan for x in values if x > 0 or x is np.nan]
 
     if show is True:
         _ecg_delineate_plot(


### PR DESCRIPTION
# Description

Resolves #1127. Fixes error where certain waveforms would return a peaks_dict where 'ECG_Q_Peaks` had fewer elements than input `rpeaks`

# Proposed Changes

I changed line 206 to return np.nan if qpeaks detected an index of 0. np.nan was chosen as in all examples the identified qpeak was incorrectly identified. I will include in the PR a suggested change if just returning an index of 0 is the more appropriate behavior.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [X] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [X] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [X] I have added the newly added features to **News.rst** (if applicable)
