### PR TITLE
Add IBI quality method for ECG and PPG

### DIFF
--- a/neurokit2/ecg/ecg_quality.py
+++ b/neurokit2/ecg/ecg_quality.py
@@ -8,7 +8,7 @@ from ..epochs import epochs_to_df
 from ..misc import NeuroKitWarning
 from ..signal import signal_interpolate
 from ..signal.signal_power import signal_power
-from ..signal.signal_quality import signal_quality
+from ..signal.signal_templatequality import signal_templatequality
 from ..stats import distance, rescale
 from .ecg_peaks import ecg_peaks
 from .ecg_segment import ecg_segment
@@ -75,7 +75,7 @@ def ecg_quality(
 
     See Also
     --------
-    ecg_segment, ecg_delineate, signal_quality
+    ecg_segment, ecg_delineate, signal_templatequality
 
     References
     ----------
@@ -140,7 +140,7 @@ def ecg_quality(
             _, rpeaks = ecg_peaks(ecg_cleaned, sampling_rate=sampling_rate)
             rpeaks = rpeaks["ECG_R_Peaks"]
         # Assess quality using template matching
-        quality = signal_quality(
+        quality = signal_templatequality(
             ecg_cleaned,
             beat_inds=rpeaks,
             signal_type="ecg",

--- a/neurokit2/ecg/ecg_quality.py
+++ b/neurokit2/ecg/ecg_quality.py
@@ -9,6 +9,7 @@ from ..misc import NeuroKitWarning
 from ..signal import signal_interpolate
 from ..signal.signal_power import signal_power
 from ..signal.signal_templatequality import signal_templatequality
+from ..signal.signal_ibiquality import signal_ibiquality
 from ..stats import distance, rescale
 from .ecg_peaks import ecg_peaks
 from .ecg_segment import ecg_segment
@@ -47,6 +48,14 @@ def ecg_quality(
       in this algorithm. The indices were originally weighted with a ratio of [0.4, 0.4, 0.1, 0.1]
       to generate the final classification outcome, but because qSQI was dropped, the weights have
       been rearranged to [0.6, 0.2, 0.2] for pSQI, kSQI and basSQI respectively.
+    
+    * The ``"ho2025"` method (Ho et al., 2025) assesses ECG quality on a beat-by-beat basis by predicting
+      whether each RR-interval is accurate. To do so, QRS complexes are detected using a primary QRS detector,
+      and each RR-interval is predicted to be accurate only if a secondary QRS detector detects QRS complexes
+      in the same positions (within a tolerance). In this implementation, all signal samples within an
+      RR-interval are rated as high quality (1) if that RR-interval is predicted to be accurate, or low
+      quality (0) if that RR-interval is predicted to be inaccurate. This approach was derived from the
+      previously proposed bSQI approach.
 
     Parameters
     ----------
@@ -58,7 +67,8 @@ def ecg_quality(
     sampling_rate : int
         The sampling frequency of the signal (in Hz, i.e., samples/second).
     method : str
-        The method for computing ECG signal quality, can be ``"averageQRS"`` (default) or ``"zhao2018"``.
+        The method for computing ECG signal quality, can be ``"averageQRS"`` (default), ``"zhao2018"``,
+        ``"templatematch"``, or ``"ho2025"``.
     approach : str
         The data fusion approach as documented in Zhao et al. (2018). Can be ``"simple"``
         or ``"fuzzy"``. The former performs simple heuristic fusion of SQIs and the latter performs
@@ -75,7 +85,7 @@ def ecg_quality(
 
     See Also
     --------
-    ecg_segment, ecg_delineate, signal_templatequality
+    ecg_segment, ecg_delineate, signal_templatequality, signal_ibi_quality
 
     References
     ----------
@@ -84,6 +94,8 @@ def ecg_quality(
       Physiology, 9, 727.
     * Orphanidou, C. et al. (2015). "Signal-quality indices for the electrocardiogram and photoplethysmogram:
       derivation and applications to wireless monitoring". IEEE Journal of Biomedical and Health Informatics, 19(3), 832-8.
+    * Ho, S.Y.S et al. (2025). "Accurate RR-interval extraction from single-lead, telehealth electrocardiogram signals.
+      medRxiv, 2025.03.10.25323655. https://doi.org/10.1101/2025.03.10.25323655
 
     Examples
     --------
@@ -146,6 +158,15 @@ def ecg_quality(
             signal_type="ecg",
             sampling_rate=sampling_rate,
             method="templatematch",
+        )
+    elif method in ["ho2025", "ho"]:
+        # Assess quality using Ho2025 method (RR-interval accuracy prediction)
+        quality = signal_ibiquality(
+            ecg_cleaned, 
+            signal_type="ecg",
+            primary_detector="unsw",
+            secondary_detector="neurokit",
+            sampling_rate=sampling_rate,
         )
 
     return quality

--- a/neurokit2/ppg/ppg_quality.py
+++ b/neurokit2/ppg/ppg_quality.py
@@ -1,7 +1,7 @@
 # - * - coding: utf-8 - * -
 
 from .ppg_peaks import ppg_peaks
-from ..signal.signal_quality import signal_quality
+from ..signal.signal_templatequality import signal_templatequality
 
 
 def ppg_quality(ppg_cleaned, peaks=None, sampling_rate=1000, method="templatematch"):
@@ -90,7 +90,7 @@ def ppg_quality(ppg_cleaned, peaks=None, sampling_rate=1000, method="templatemat
         )
 
     # Run
-    quality = signal_quality(
+    quality = signal_templatequality(
         ppg_cleaned,
         beat_inds=peaks,
         signal_type="ppg",

--- a/neurokit2/ppg/ppg_quality.py
+++ b/neurokit2/ppg/ppg_quality.py
@@ -44,7 +44,7 @@ def ppg_quality(ppg_cleaned, peaks=None, sampling_rate=1000, method="templatemat
 
     See Also
     --------
-    signal_quality
+    signal_templatequality
 
     References
     ----------

--- a/neurokit2/ppg/ppg_quality.py
+++ b/neurokit2/ppg/ppg_quality.py
@@ -2,6 +2,7 @@
 
 from .ppg_peaks import ppg_peaks
 from ..signal.signal_templatequality import signal_templatequality
+from ..signal.signal_ibiquality import signal_ibiquality
 
 
 def ppg_quality(ppg_cleaned, peaks=None, sampling_rate=1000, method="templatematch"):
@@ -23,6 +24,15 @@ def ppg_quality(ppg_cleaned, peaks=None, sampling_rate=1000, method="templatemat
       indicate increasing disimilarity. The original method used dynamic time-warping to align the pulse
       waves prior to calculating the level of dsimilarity, whereas this implementation does not currently
       include this step.
+    
+    * The ``"ho2025"` method (Ho et al., 2025) assesses PPG quality on a beat-by-beat basis by predicting
+      whether each interbeat-interval (IBI) is accurate. To do so, beats are detected using a primary beat detector,
+      and each IBI is predicted to be accurate only if a secondary beat detector detects beats
+      in the same positions (within a tolerance). In this implementation, all signal samples within an
+      IBI are rated as high quality (1) if that IBI is predicted to be accurate, or low
+      quality (0) if that IBI is predicted to be inaccurate. Ho et al. proposed this approach for the ECG, and here 
+      it has been applied to the PPG. The general approach was derived by Ho et al from the previously proposed bSQI
+      approach.
 
     Parameters
     ----------
@@ -34,17 +44,19 @@ def ppg_quality(ppg_cleaned, peaks=None, sampling_rate=1000, method="templatemat
     sampling_rate : int
         The sampling frequency of the signal (in Hz, i.e., samples/second).
     method : str
-        The method for computing PPG signal quality, can be ``"templatematch"`` (default).
+        The method for computing PPG signal quality, can be ``"templatematch"`` (default), ``"disimilarity"``,
+        or ``"ho2025"``.
 
     Returns
     -------
     quality : array
         Vector containing the quality index ranging from 0 to 1 for ``"templatematch"`` method,
-        or an unbounded value (where 0 indicates high quality) for ``"disimilarity"`` method.
+        or an unbounded value (where 0 indicates high quality) for ``"disimilarity"`` method,
+        or zeros and ones (where 1 indicates high quality) for ``"ho2025"`` method.
 
     See Also
     --------
-    signal_templatequality
+    signal_templatequality, signal_ibiquality
 
     References
     ----------
@@ -52,6 +64,8 @@ def ppg_quality(ppg_cleaned, peaks=None, sampling_rate=1000, method="templatemat
       derivation and applications to wireless monitoring". IEEE Journal of Biomedical and Health Informatics, 19(3), 832-8.
     * Sabeti E. et al. (2019). Signal quality measure for pulsatile physiological signals using morphological features:
       Applications in reliability measure for pulse oximetry. Informatics in Medicine Unlocked, 16, 100222.
+    * Ho, S.Y.S et al. (2025). "Accurate RR-interval extraction from single-lead, telehealth electrocardiogram signals.
+      medRxiv, 2025.03.10.25323655. https://doi.org/10.1101/2025.03.10.25323655
 
     Examples
     --------
@@ -80,22 +94,34 @@ def ppg_quality(ppg_cleaned, peaks=None, sampling_rate=1000, method="templatemat
         peaks = peaks["PPG_Peaks"]
 
     # Sanitise method name
-    if method.lower() in ["templatematch", "orphanidou2015"]:
+    if method in ["templatematch", "orphanidou2015"]:
         method = "templatematch"
-    elif method.lower() in ["disimilarity", "sabeti2019"]:
+    elif method in ["disimilarity", "sabeti2019"]:
         method = "disimilarity"
+    elif method in ["ho2025", "ho"]:
+        method = "ho2025"
     else:
         raise ValueError(
-            f"Method '{method}' not recognised. Please use 'templatematch' or 'disimilarity'."
+            f"Method '{method}' not recognised. Please use 'templatematch', 'disimilarity', or 'ho2025'."
         )
 
-    # Run
-    quality = signal_templatequality(
-        ppg_cleaned,
-        beat_inds=peaks,
-        signal_type="ppg",
-        sampling_rate=sampling_rate,
-        method=method,
-    )
+    # Run 'templatematch' and 'disimilarity' methods
+    if method in ["templatematch", "disimilarity"]:
+        quality = signal_templatequality(
+            ppg_cleaned,
+            beat_inds=peaks,
+            signal_type="ppg",
+            sampling_rate=sampling_rate,
+            method=method,
+        )
+    elif method=="ho2025":
+        # Assess quality using Ho2025 method (IBI accuracy prediction)
+        quality = signal_ibiquality(
+            ppg_cleaned, 
+            signal_type="ppg",
+            primary_detector="charlton",
+            secondary_detector="elgendi",
+            sampling_rate=sampling_rate,
+        )
 
     return quality

--- a/neurokit2/ppg/ppg_segment.py
+++ b/neurokit2/ppg/ppg_segment.py
@@ -51,10 +51,13 @@ def ppg_segment(ppg_cleaned, peaks=None, sampling_rate=1000, show=False, **kwarg
     if len(ppg_cleaned) < sampling_rate * 4:
         raise ValueError("The data length is too small to be segmented.")
 
+    output = signal_cyclesegment(ppg_cleaned, peaks, ratio_pre=0.3, sampling_rate=sampling_rate, show=show, signal_name="ppg", **kwargs)
+
+    # if asked to return an axis handle
     if show == "return":
-        ax = signal_cyclesegment(ppg_cleaned, peaks, ratio_pre=0.3, sampling_rate=sampling_rate, show=show, signal_name="ppg", **kwargs)
-        return ax
-    else:
-        heartbeats, average_hr = signal_cyclesegment(ppg_cleaned, peaks, ratio_pre=0.3, sampling_rate=sampling_rate, show=show, signal_name="ppg", **kwargs)
+        return output
+    
+    # else, extract heartbeats
+    heartbeats, _ = output
 
     return heartbeats

--- a/neurokit2/ppg/ppg_segment.py
+++ b/neurokit2/ppg/ppg_segment.py
@@ -1,13 +1,10 @@
 # - * - coding: utf-8 - * -
-import numpy as np
-
-from ..ecg.ecg_segment import _ecg_segment_plot, _ecg_segment_window
-from ..epochs import epochs_create
 from .ppg_peaks import ppg_peaks
+from ..signal import signal_cyclesegment
 
 
 def ppg_segment(ppg_cleaned, peaks=None, sampling_rate=1000, show=False, **kwargs):
-    """**Segment an PPG signal into single heartbeats**
+    """**Segment a PPG signal into single heartbeats**
 
     Segment a PPG signal into single heartbeats. Convenient for visualizing all the heart beats.
 
@@ -54,30 +51,10 @@ def ppg_segment(ppg_cleaned, peaks=None, sampling_rate=1000, show=False, **kwarg
     if len(ppg_cleaned) < sampling_rate * 4:
         raise ValueError("The data length is too small to be segmented.")
 
-    epochs_start, epochs_end, average_hr = _ecg_segment_window(
-        rpeaks=peaks,
-        sampling_rate=sampling_rate,
-        desired_length=len(ppg_cleaned),
-        ratio_pre=0.3,
-    )
-    heartbeats = epochs_create(
-        ppg_cleaned,
-        peaks,
-        sampling_rate=sampling_rate,
-        epochs_start=epochs_start,
-        epochs_end=epochs_end,
-    )
-
-    # pad last heartbeat with nan so that segments are equal length
-    last_heartbeat_key = str(np.max(np.array(list(heartbeats.keys()), dtype=int)))
-    after_last_index = heartbeats[last_heartbeat_key]["Index"] >= len(ppg_cleaned)
-    heartbeats[last_heartbeat_key].loc[after_last_index, "Signal"] = np.nan
-
-    if show is not False:
-        ax = _ecg_segment_plot(
-            heartbeats, heartrate=average_hr, ytitle="PPG", color="#E91E63", **kwargs
-        )
     if show == "return":
+        ax = signal_cyclesegment(ppg_cleaned, peaks, ratio_pre=0.3, sampling_rate=sampling_rate, show=show, signal_name="ppg", **kwargs)
         return ax
+    else:
+        heartbeats, average_hr = signal_cyclesegment(ppg_cleaned, peaks, ratio_pre=0.3, sampling_rate=sampling_rate, show=show, signal_name="ppg", **kwargs)
 
     return heartbeats

--- a/neurokit2/rsp/__init__.py
+++ b/neurokit2/rsp/__init__.py
@@ -18,26 +18,28 @@ from .rsp_rate import rsp_rate
 from .rsp_rav import rsp_rav
 from .rsp_rrv import rsp_rrv
 from .rsp_rvt import rsp_rvt
+from .rsp_segment import rsp_segment
 from .rsp_simulate import rsp_simulate
 from .rsp_symmetry import rsp_symmetry
 
 __all__ = [
-    "rsp_simulate",
+    "rsp_amplitude",
+    "rsp_analyze",
     "rsp_clean",
+    "rsp_eventrelated",
     "rsp_findpeaks",
     "rsp_fixpeaks",
+    "rsp_intervalrelated",
+    "rsp_methods",
     "rsp_peaks",
     "rsp_phase",
-    "rsp_amplitude",
-    "rsp_process",
     "rsp_plot",
-    "rsp_eventrelated",
+    "rsp_process",
     "rsp_rav",
     "rsp_rrv",
     "rsp_rvt",
-    "rsp_intervalrelated",
-    "rsp_analyze",
     "rsp_rate",
+    "rsp_segment",
+    "rsp_simulate",
     "rsp_symmetry",
-    "rsp_methods",
 ]

--- a/neurokit2/rsp/__init__.py
+++ b/neurokit2/rsp/__init__.py
@@ -14,6 +14,7 @@ from .rsp_peaks import rsp_peaks
 from .rsp_phase import rsp_phase
 from .rsp_plot import rsp_plot
 from .rsp_process import rsp_process
+from .rsp_quality import rsp_quality
 from .rsp_rate import rsp_rate
 from .rsp_rav import rsp_rav
 from .rsp_rrv import rsp_rrv
@@ -35,6 +36,7 @@ __all__ = [
     "rsp_phase",
     "rsp_plot",
     "rsp_process",
+    "rsp_quality",
     "rsp_rav",
     "rsp_rrv",
     "rsp_rvt",

--- a/neurokit2/rsp/rsp_clean.py
+++ b/neurokit2/rsp/rsp_clean.py
@@ -21,6 +21,7 @@ def rsp_clean(rsp_signal, sampling_rate=1000, method="khodadad2018", **kwargs):
       detrending).
     * **hampel**: Applies a median-based Hampel filter by replacing values which are 3 (can be
       changed via ``threshold``) :func:`.mad` away from the rolling median.
+    * **charlton2021**: Second order 1 Hz lowpass Butterworth filter.
 
     Parameters
     ----------
@@ -71,6 +72,8 @@ def rsp_clean(rsp_signal, sampling_rate=1000, method="khodadad2018", **kwargs):
       Characteristics of respiratory measures in young adults scanned at rest,
       including systematic changes and “missed” deep breaths.
       NeuroImage, Volume 204, 116234
+    * Charlton, P.H, et al. (2021). An impedance pneumography signal quality index: Design, assessment
+      and application to respiratory rate monitoring. Biomedical Signal Processing and Control, 65, 102339.
 
     """
     rsp_signal = as_vector(rsp_signal)
@@ -95,11 +98,13 @@ def rsp_clean(rsp_signal, sampling_rate=1000, method="khodadad2018", **kwargs):
             rsp_signal,
             **kwargs,
         )
+    elif method in ["charlton", "charlton2021"]:
+        clean = _rsp_clean_charlton2021(rsp_signal, sampling_rate)
     elif method is None or method == "none":
         clean = rsp_signal
     else:
         raise ValueError(
-            "NeuroKit error: rsp_clean(): 'method' should be one of 'khodadad2018', 'biosppy' or 'hampel'."
+            "NeuroKit error: rsp_clean(): 'method' should be one of 'charlton2021', 'khodadad2018', 'biosppy' or 'hampel'."
         )
 
     return clean
@@ -113,6 +118,28 @@ def _rsp_clean_missing(rsp_signal):
     rsp_signal = pd.DataFrame.pad(pd.Series(rsp_signal))
 
     return rsp_signal
+
+
+# =============================================================================
+# Charlton et al. (2021)
+# =============================================================================
+def _rsp_clean_charlton2021(rsp_signal, sampling_rate=1000):
+    """The algorithm is a low-pass filter with cutoff of 1 Hz (i.e. 60 breaths per minute).
+    It is loosely based on that described in `Charlton et al. (2021)
+
+    <https://doi.org/10.1016/j.bspc.2020.102339>`_.
+
+    """
+    
+    clean = signal_filter(
+        rsp_signal,
+        sampling_rate=sampling_rate,
+        highcut=1,
+        order=2,
+        method="butterworth",  # Whereas Charlton et al used an FIR filter designed using the Kaiser window method
+    )
+
+    return clean
 
 
 # =============================================================================

--- a/neurokit2/rsp/rsp_clean.py
+++ b/neurokit2/rsp/rsp_clean.py
@@ -94,10 +94,7 @@ def rsp_clean(rsp_signal, sampling_rate=1000, method="khodadad2018", **kwargs):
     elif method == "biosppy":
         clean = _rsp_clean_biosppy(rsp_signal, sampling_rate)
     elif method in ["power", "power2020", "hampel"]:
-        clean = _rsp_clean_hampel(
-            rsp_signal,
-            **kwargs,
-        )
+        clean = _rsp_clean_hampel(rsp_signal,**kwargs)
     elif method in ["charlton", "charlton2021"]:
         clean = _rsp_clean_charlton2021(rsp_signal, sampling_rate)
     elif method is None or method == "none":

--- a/neurokit2/rsp/rsp_clean.py
+++ b/neurokit2/rsp/rsp_clean.py
@@ -21,7 +21,8 @@ def rsp_clean(rsp_signal, sampling_rate=1000, method="khodadad2018", **kwargs):
       detrending).
     * **hampel**: Applies a median-based Hampel filter by replacing values which are 3 (can be
       changed via ``threshold``) :func:`.mad` away from the rolling median.
-    * **charlton2021**: Second order 1 Hz lowpass Butterworth filter.
+    * **charlton2021**: Second order 1 Hz lowpass Butterworth filter. Note that is doesn't include
+      the Tukey window step proposed in Charlton et al.
 
     Parameters
     ----------

--- a/neurokit2/rsp/rsp_findpeaks.py
+++ b/neurokit2/rsp/rsp_findpeaks.py
@@ -91,10 +91,10 @@ def rsp_findpeaks(
             peak_prominence=peak_prominence,
         )
     elif method in ["schafer", "schafer2008"]:
-        info = _rsp_findpeaks_schafer(cleaned, sampling_rate=sampling_rate)
+        info = _rsp_findpeaks_schafer(cleaned)
     else:
         raise ValueError(
-            "NeuroKit error: rsp_findpeaks(): 'method' should be one of 'khodadad2018', 'scipy' or 'biosppy'."
+            "NeuroKit error: rsp_findpeaks(): 'method' should be one of 'khodadad2018', 'scipy', 'biosppy', or 'schafer2008'."
         )
 
     return info
@@ -122,11 +122,12 @@ def _rsp_findpeaks_biosppy(rsp_cleaned, sampling_rate):
     return info
 
 
-def _rsp_findpeaks_schafer(rsp_cleaned, sampling_rate):
+def _rsp_findpeaks_schafer(rsp_cleaned):
     """Respiratory peak and trough detection based on Schafer et al. (2008)
     https://doi.org/10.1007/s10439-007-9428-1
+    
     Based on Charlton's MATLAB implementation at:
-    https://github.com/peterhcharlton/impSQI/ 
+    https://github.com/peterhcharlton/impSQI/
     """
 
     # Invert and detrend signal

--- a/neurokit2/rsp/rsp_findpeaks.py
+++ b/neurokit2/rsp/rsp_findpeaks.py
@@ -25,8 +25,8 @@ def rsp_findpeaks(
     sampling_rate : int
         The sampling frequency of :func:`.rsp_cleaned` (in Hz, i.e., samples/second).
     method : str
-        The processing pipeline to apply. Can be one of ``"khodadad2018"`` (default), ``"scipy"`` or
-        ``"biosppy"``.
+        The processing pipeline to apply. Can be one of ``"khodadad2018"`` (default), ``"scipy"``,
+        ``"biosppy"``, or ``"schafer2008"``.
     amplitude_min : float
         Only applies if method is ``"khodadad2018"``. Extrema that have a vertical distance smaller
         than(outlier_threshold * average vertical distance) to any direct neighbour are removed as
@@ -90,6 +90,8 @@ def rsp_findpeaks(
             peak_distance=peak_distance,
             peak_prominence=peak_prominence,
         )
+    elif method in ["schafer", "schafer2008"]:
+        info = _rsp_findpeaks_schafer(cleaned, sampling_rate=sampling_rate)
     else:
         raise ValueError(
             "NeuroKit error: rsp_findpeaks(): 'method' should be one of 'khodadad2018', 'scipy' or 'biosppy'."
@@ -117,6 +119,49 @@ def _rsp_findpeaks_biosppy(rsp_cleaned, sampling_rate):
     troughs = np.delete(troughs, outlier_idcs)
 
     info = {"RSP_Peaks": peaks, "RSP_Troughs": troughs}
+    return info
+
+
+def _rsp_findpeaks_schafer(rsp_cleaned, sampling_rate):
+    """Respiratory peak and trough detection based on Schafer et al. (2008)
+    https://doi.org/10.1007/s10439-007-9428-1
+    Based on Charlton's MATLAB implementation at:
+    https://github.com/peterhcharlton/impSQI/ 
+    """
+
+    # Invert and detrend signal
+    signal = -1 * scipy.signal.detrend(rsp_cleaned)
+
+    # First differences
+    diffs = np.diff(signal)
+
+    # Identify peaks
+    left = diffs[:-1] > 0
+    right = diffs[1:] < 0
+    peaks = np.where(left & right)[0] + 1  # +1 to align with original indexing
+
+    # Identify troughs
+    left = diffs[:-1] < 0
+    right = diffs[1:] > 0
+    troughs = np.where(left & right)[0] + 1
+
+    # Keep only relevant peaks: above threshold
+    if len(peaks) > 0:
+        q3 = np.percentile(signal[peaks], 75)
+        thresh = 0.2 * q3
+        rel_peaks = peaks[signal[peaks] > thresh]
+    else:
+        rel_peaks = np.array([], dtype=int)
+
+    # Keep only relevant troughs: below threshold
+    if len(troughs) > 0:
+        q3t = np.percentile(signal[troughs], 25)
+        thresh = 0.2 * q3t
+        rel_troughs = troughs[signal[troughs] < thresh]
+    else:
+        rel_troughs = np.array([], dtype=int)
+
+    info = {"RSP_Peaks": rel_peaks, "RSP_Troughs": rel_troughs}
     return info
 
 

--- a/neurokit2/rsp/rsp_peaks.py
+++ b/neurokit2/rsp/rsp_peaks.py
@@ -17,6 +17,7 @@ def rsp_peaks(rsp_cleaned, sampling_rate=1000, method="khodadad2018", **kwargs):
       ``resp()`` function.
     * **scipy** Uses the `scipy <https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.find_peaks.html>`_
       peak-detection function.
+    * **schafer2008**: Uses the count-orig algorithm proposed in Schafer et al. (2008).
 
     Parameters
     ----------
@@ -25,8 +26,8 @@ def rsp_peaks(rsp_cleaned, sampling_rate=1000, method="khodadad2018", **kwargs):
     sampling_rate : int
         The sampling frequency of :func:`.rsp_cleaned` (in Hz, i.e., samples/second).
     method : str
-        The processing pipeline to apply. Can be one of ``"khodadad2018"`` (default), ``"biosppy"``
-        or ``"scipy"``.
+        The processing pipeline to apply. Can be one of ``"khodadad2018"`` (default), ``"biosppy"``,
+        ``"scipy"``, or ``"schafer2008"``.
     **kwargs
         Other arguments to be passed to the different peak finding methods. See
         :func:`.rsp_findpeaks`.
@@ -70,10 +71,27 @@ def rsp_peaks(rsp_cleaned, sampling_rate=1000, method="khodadad2018", **kwargs):
     * Khodadad, D., Nordebo, S., Müller, B., Waldmann, A., Yerworth, R., Becher, T., ... & Bayford,
       R. (2018). Optimized breath detection algorithm in electrical impedance tomography.
       Physiological measurement, 39(9), 094001.
+    * Schafer, A. and Kratky K.W. (2008). Estimation of breathing rate from respiratory sinus arrhythmia:
+      comparison of various methods. Annals of Biomedical Engineering, 36(3), 476–85.
 
     """
-    info = rsp_findpeaks(rsp_cleaned, sampling_rate=sampling_rate, method=method, **kwargs)
+    # Store info
+    info = {"method_peaks": method.lower(), "method_fixpeaks": "None"}
+
+    # Find peaks
+    info.update(
+        rsp_findpeaks(
+            rsp_cleaned,
+            sampling_rate=sampling_rate,
+            method=method,
+            **kwargs
+        )
+    )
+
+    # Fix peaks
     info = rsp_fixpeaks(info)
+
+    # Format peaks
     peak_signal = signal_formatpeaks(
         info, desired_length=len(rsp_cleaned), peak_indices=info["RSP_Peaks"]
     )

--- a/neurokit2/rsp/rsp_quality.py
+++ b/neurokit2/rsp/rsp_quality.py
@@ -14,7 +14,9 @@ def rsp_quality(rsp_cleaned, peaks=None, sampling_rate=1000, method="templatemat
       individual breath and an average (template) breath shape. This index is therefore
       relative: 1 corresponds to breaths that are closest to the average breath shape (i.e.
       correlate exactly with it) and 0 corresponds to there being no correlation with the average
-      breath shape. Note that Charlton et al. use a particular breath detection algorithm.
+      breath shape. Note that for pre-processing, Charlton et al. cleaned the signal with a low-pass filter
+      below 1 Hz (the "charlton2021" method in rsp_clean), and used the "schafer2008" breath detection
+      algorithm (the "schafer2008" method in rsp_peaks).
 
     Parameters
     ----------
@@ -66,7 +68,7 @@ def rsp_quality(rsp_cleaned, peaks=None, sampling_rate=1000, method="templatemat
 
     # Detect RSP peaks (if not done already)
     if peaks is None:
-        _, peaks = rsp_peaks(rsp_cleaned, sampling_rate=sampling_rate)
+        _, peaks = rsp_peaks(rsp_cleaned, sampling_rate=sampling_rate, method="schafer2008")
         peaks = peaks["RSP_Peaks"]
 
     # Sanitise method name

--- a/neurokit2/rsp/rsp_quality.py
+++ b/neurokit2/rsp/rsp_quality.py
@@ -1,0 +1,89 @@
+# - * - coding: utf-8 - * -
+
+from .rsp_peaks import rsp_peaks
+from ..signal.signal_templatequality import signal_templatequality
+
+
+def rsp_quality(rsp_cleaned, peaks=None, sampling_rate=1000, method="templatematch"):
+    """**RSP Signal Quality Assessment**
+
+    Assess the quality of the RSP Signal. using template matching:
+
+    * The ``"templatematch"`` method (loosely based on Charlton et al., 2021) computes a continuous
+      index of quality of the RSP signal, by calculating the correlation coefficient between each
+      individual breath and an average (template) breath shape. This index is therefore
+      relative: 1 corresponds to breaths that are closest to the average breath shape (i.e.
+      correlate exactly with it) and 0 corresponds to there being no correlation with the average
+      breath shape. Note that Charlton et al. use a particular breath detection algorithm.
+
+    Parameters
+    ----------
+    rsp_cleaned : Union[list, np.array, pd.Series]
+        The cleaned RSP signal in the form of a vector of values.
+    peaks : tuple or list
+        The list of RSP peak samples returned by ``rsp_peaks()``. If None, peaks is computed from
+        the signal input.
+    sampling_rate : int
+        The sampling frequency of the signal (in Hz, i.e., samples/second).
+    method : str
+        The method for computing RSP signal quality. The only option is ``"templatematch"`` (default).
+
+    Returns
+    -------
+    quality : array
+        Vector containing the quality index ranging from 0 to 1.
+
+    See Also
+    --------
+    signal_templatequality
+
+    References
+    ----------
+    * Charlton, P.H, et al. (2021). An impedance pneumography signal quality index: Design, assessment
+      and application to respiratory rate monitoring. Biomedical Signal Processing and Control, 65, 102339.
+
+    Examples
+    --------
+    * **Example 1:** 'templatematch' method
+
+    .. ipython:: python
+
+      import neurokit2 as nk
+
+      sampling_rate=50
+      rsp = nk.rsp_simulate(duration=30, sampling_rate=sampling_rate, method="breathmetrics")
+      rsp_cleaned = nk.rsp_clean(rsp, sampling_rate=sampling_rate, method="charlton")
+      quality = nk.rsp_quality(rsp_cleaned, sampling_rate=sampling_rate, method="templatematch")
+
+      @savefig p_rsp_quality.png scale=100%
+      nk.signal_plot([rsp_cleaned, quality], standardize=True)
+      @suppress
+      plt.close()
+
+    """
+
+    method = method.lower()  # remove capitalised letters
+
+    # Detect RSP peaks (if not done already)
+    if peaks is None:
+        _, peaks = rsp_peaks(rsp_cleaned, sampling_rate=sampling_rate)
+        peaks = peaks["RSP_Peaks"]
+
+    # Sanitise method name
+    if method.lower() in ["templatematch", "charlton2021", "charlton"]:
+        method = "templatematch"
+    else:
+        raise ValueError(
+            f"Method '{method}' not recognised. Please use 'templatematch'."
+        )
+
+    # Run
+    quality = signal_templatequality(
+        rsp_cleaned,
+        beat_inds=peaks,
+        signal_type="rsp",
+        sampling_rate=sampling_rate,
+        method=method,
+    )
+
+    return quality

--- a/neurokit2/rsp/rsp_segment.py
+++ b/neurokit2/rsp/rsp_segment.py
@@ -1,0 +1,57 @@
+# - * - coding: utf-8 - * -
+from .rsp_peaks import rsp_peaks
+from ..signal import signal_cyclesegment
+
+
+def rsp_segment(rsp_cleaned, peaks=None, sampling_rate=1000, show=False, **kwargs):
+    """**Segment a respiratory signal into individual breaths**
+
+    Segment a respiratory signal into individual breaths. Convenient for visualizing all the breaths.
+
+    Parameters
+    ----------
+    rsp_cleaned : Union[list, np.array, pd.Series]
+        The cleaned respiratory channel as returned by ``rsp_clean()``.
+    peaks : dict
+        The samples at which the peaks (exhalation onsets) occur. Dict returned by ``rsp_peaks()``. Defaults to ``None``.
+    sampling_rate : int
+        The sampling frequency of ``rsp_cleaned`` (in Hz, i.e., samples/second). Defaults to 1000.
+    show : bool
+        If ``True``, will return a plot of breaths. Defaults to ``False``.
+    **kwargs
+        Other arguments to be passed.
+
+    Returns
+    -------
+    dict
+        A dict containing DataFrames for all segmented breaths.
+
+    See Also
+    --------
+    rsp_clean, rsp_peaks
+
+    Examples
+    --------
+    .. ipython:: python
+
+      import neurokit2 as nk
+
+      sampling_rate=100
+      rsp = nk.rsp_simulate(duration=30, sampling_rate=sampling_rate, method="breathmetrics")
+      @savefig p_rsp_segment.png scale=100%
+      rsp_epochs = nk.rsp_segment(rsp, sampling_rate=sampling_rate, show=True)
+      @suppress
+      plt.close()
+
+    """
+    # Sanitize inputs
+    if peaks is None:
+        _, peaks = rsp_peaks(rsp_cleaned, sampling_rate=sampling_rate)
+        peaks = peaks["RSP_Peaks"]
+
+    if len(rsp_cleaned) < sampling_rate * 10:
+        raise ValueError("The data length is too small to be segmented.")
+
+    breaths, average_rr = signal_cyclesegment(rsp_cleaned, peaks, sampling_rate=sampling_rate, show=show, signal_name="rsp")
+
+    return breaths

--- a/neurokit2/rsp/rsp_segment.py
+++ b/neurokit2/rsp/rsp_segment.py
@@ -52,6 +52,13 @@ def rsp_segment(rsp_cleaned, peaks=None, sampling_rate=1000, show=False, **kwarg
     if len(rsp_cleaned) < sampling_rate * 10:
         raise ValueError("The data length is too small to be segmented.")
 
-    breaths, average_rr = signal_cyclesegment(rsp_cleaned, peaks, sampling_rate=sampling_rate, show=show, signal_name="rsp")
+    output = signal_cyclesegment(rsp_cleaned, peaks, sampling_rate=sampling_rate, show=show, signal_name="rsp", **kwargs)
+
+    # if an axes object is requested
+    if show == "return":
+        return output
+    
+    # else extract breaths
+    breaths, _ = output
 
     return breaths

--- a/neurokit2/signal/__init__.py
+++ b/neurokit2/signal/__init__.py
@@ -29,7 +29,7 @@ from .signal_simulate import signal_simulate
 from .signal_smooth import signal_smooth
 from .signal_surrogate import signal_surrogate
 from .signal_synchrony import signal_synchrony
-from .signal_quality import signal_quality
+from .signal_templatequality import signal_templatequality
 from .signal_tidypeaksonsets import signal_tidypeaksonsets
 from .signal_timefrequency import signal_timefrequency
 from .signal_zerocrossings import signal_zerocrossings
@@ -62,8 +62,8 @@ __all__ = [
     "signal_decompose",
     "signal_recompose",
     "signal_surrogate",
+    "signal_templatequality",
     "signal_tidypeaksonsets",
-    "signal_quality",
     "signal_timefrequency",
     "signal_sanitize",
     "signal_flatline",

--- a/neurokit2/signal/__init__.py
+++ b/neurokit2/signal/__init__.py
@@ -13,6 +13,7 @@ from .signal_findpeaks import signal_findpeaks
 from .signal_fixpeaks import signal_fixpeaks
 from .signal_flatline import signal_flatline
 from .signal_formatpeaks import signal_formatpeaks
+from .signal_ibiquality import signal_ibiquality
 from .signal_interpolate import signal_interpolate
 from .signal_merge import signal_merge
 from .signal_noise import signal_noise
@@ -68,4 +69,5 @@ __all__ = [
     "signal_sanitize",
     "signal_flatline",
     "signal_fillmissing",
+    "signal_ibiquality",
 ]

--- a/neurokit2/signal/signal_cyclesegment.py
+++ b/neurokit2/signal/signal_cyclesegment.py
@@ -104,7 +104,7 @@ def _segment_plot(cycles, cyclerate=0, signal_name="signal", color="#F44336", ax
     if ax is None:
         _, ax = plt.subplots()
     signal_name = signal_name.lower()
-    if signal_name in ["ecg","ppg"]:
+    if signal_name in ["ecg", "ppg"]:
         cycle_name = "beat"
         rate_name = "heart rate"
         rate_unit = "bpm"

--- a/neurokit2/signal/signal_cyclesegment.py
+++ b/neurokit2/signal/signal_cyclesegment.py
@@ -1,10 +1,11 @@
 # - * - coding: utf-8 - * -
+import matplotlib.pyplot as plt
 import numpy as np
 
-from ..epochs import epochs_create
+from ..epochs import epochs_create, epochs_to_df
 from ..signal.signal_rate import signal_rate
 
-def signal_cyclesegment(signal_cleaned, cycle_indices, sampling_rate=1000, **kwargs):
+def signal_cyclesegment(signal_cleaned, cycle_indices, ratio_pre=0.5, sampling_rate=1000, show=False, signal_name="signal", **kwargs):
     """**Segment a signal into individual cycles**
 
     Segment a signal (e.g. ECG, PPG, respiratory) into individual cycles (e.g. heartbeats, pulse waves, breaths).
@@ -16,8 +17,16 @@ def signal_cyclesegment(signal_cleaned, cycle_indices, sampling_rate=1000, **kwa
     cycle_indices : dict
         The samples indicating individual cycles (such as PPG peaks or ECG R-peaks), such as a dict
         returned by ``ppg_peaks()``.
+    ratio_pre : float
+        The proportion of the cycle window which takes place before the cycle index (e.g. the proportion of the
+        interbeat interval which takes place before the PPG pulse peak or ECG R peak).
     sampling_rate : int
         The sampling frequency of ``signal_cleaned`` (in Hz, i.e., samples/second). Defaults to 1000.
+    show : bool
+        If ``True``, will return a plot of cycles. Defaults to ``False``. If "return", returns
+        the axis of the plot.
+    signal_name : str
+        The name of the signal (only used for plotting).
     **kwargs
         Other arguments to be passed.
 
@@ -25,6 +34,8 @@ def signal_cyclesegment(signal_cleaned, cycle_indices, sampling_rate=1000, **kwa
     -------
     dict
         A dict containing DataFrames for all segmented cycles.
+    average_cycle_rate : float
+        The average cycle rate (e.g. heart rate, respiratory rate) (in Hz, i.e., samples/second)
 
     See Also
     --------
@@ -39,13 +50,11 @@ def signal_cyclesegment(signal_cleaned, cycle_indices, sampling_rate=1000, **kwa
       sampling_rate = 100
       ppg = nk.ppg_simulate(duration=30, sampling_rate=sampling_rate, heart_rate=80)
       ppg_cleaned = nk.ppg_clean(ppg, sampling_rate=sampling_rate)
-      _, peaks = nk.ppg_peaks(ppg_cleaned, sampling_rate=sampling_rate)
+      signals, peaks = nk.ppg_peaks(ppg_cleaned, sampling_rate=sampling_rate)
       peaks = peaks["PPG_Peaks"]
       heartbeats = nk.signal_cyclesegment(ppg_cleaned, peaks, sampling_rate=sampling_rate)
 
     """
-
-    # To-do: This doesn't currently contain the plotting functionality of ecg_segment.
 
     if len(signal_cleaned) < sampling_rate * 4:
         raise ValueError("The data length is too small to be segmented.")
@@ -54,7 +63,7 @@ def signal_cyclesegment(signal_cleaned, cycle_indices, sampling_rate=1000, **kwa
         cycle_indices=cycle_indices,
         sampling_rate=sampling_rate,
         desired_length=len(signal_cleaned),
-        ratio_pre=0.5,
+        ratio_pre=ratio_pre,
     )
     cycles = epochs_create(
         signal_cleaned,
@@ -69,25 +78,95 @@ def signal_cyclesegment(signal_cleaned, cycle_indices, sampling_rate=1000, **kwa
     outside_bounds = cycles[last_cycle_key]["Index"] >= len(signal_cleaned)
     cycles[last_cycle_key].loc[outside_bounds, "Signal"] = np.nan
 
-    return cycles
+    # Plot or return plot axis
+    if show is not False:
+        ax = _segment_plot(cycles, cyclerate=average_cycle_rate, signal_name=signal_name, **kwargs)
+    if show == "return":
+        return ax
 
+    return cycles, average_cycle_rate
+
+
+# =============================================================================
+# Internals
+# =============================================================================
+def _segment_plot(cycles, cyclerate=0, signal_name="signal", color="#F44336", ax=None):
+    df = epochs_to_df(cycles)
+
+    # Get main signal column name
+    col = "Signal"
+
+    # Average cycle shape
+    mean_cycle = df.groupby("Time")[[col]].mean()
+    df_pivoted = df.pivot(index="Time", columns="Label", values=col)
+
+    # Prepare plot
+    if ax is None:
+        _, ax = plt.subplots()
+    signal_name = signal_name.lower()
+    if signal_name in ["ecg","ppg"]:
+        cycle_name = "beat"
+        rate_name = "heart rate"
+        rate_unit = "bpm"
+    elif signal_name == "rsp":
+        cycle_name = "breath"
+        rate_name = "respiratory rate"
+        rate_unit = "breaths per min"
+    elif signal_name == "signal":
+        cycle_name = "cycle"
+        rate_name = "cycle rate"
+        rate_unit = "per min"
+
+    ax.set_title(f"Individual {cycle_name}s (average {rate_name}: {cyclerate:0.1f} {rate_unit})")
+    ax.set_xlabel("Time (seconds)")
+    ax.set_ylabel(signal_name)
+
+    # Add Vertical line at 0
+    ax.axvline(x=0, color="grey", linestyle="--")
+
+    # Plot average cycle
+    ax.plot(
+        mean_cycle.index,
+        mean_cycle,
+        color=color,
+        linewidth=7,
+        label=f"Average {cycle_name} shape",
+        zorder=1,
+    )
+
+    # Alpha of individual cycles decreases with more cycles
+    n_cycles = df_pivoted.shape[1]
+    if n_cycles <= 1:
+        alpha = 1.0
+    else:
+        alpha = 1 / np.log2(np.log2(1 + n_cycles))
+
+    # Plot all cycles
+    ax.plot(df_pivoted, color="grey", linewidth=alpha, alpha=alpha, zorder=2)
+
+    # Legend
+    ax.legend(loc="upper right")
+    return ax
 
 def _segment_window(
-    cycle_rate=None,
     cycle_indices=None,
     sampling_rate=1000,
     desired_length=None,
     ratio_pre=0.5,
+    cycle_rate=None,
 ):
-    # Extract cycle rate
-    if cycle_rate is not None:
-        cycle_rate = np.mean(cycle_rate)
-    if cycle_indices is not None:
-        cycle_rate = np.mean(
-            signal_rate(
-                cycle_indices, sampling_rate=sampling_rate, desired_length=desired_length
+    # Determine cycle rate
+    if cycle_rate is None:
+        if cycle_indices is not None:
+            cycle_rate = np.mean(
+                signal_rate(
+                    cycle_indices, sampling_rate=sampling_rate, desired_length=desired_length
+                )
             )
-        )
+        else:
+            raise ValueError("Either `cycle_rate` or `cycle_indices` must be provided.")
+    else:
+        cycle_rate = np.mean(cycle_rate)  # In case it's an array
     
     # Modulator
     # Note: this is based on quick internal testing but could be improved

--- a/neurokit2/signal/signal_ibiquality.py
+++ b/neurokit2/signal/signal_ibiquality.py
@@ -1,0 +1,162 @@
+# - * - coding: utf-8 - * -
+import numpy as np
+
+def signal_ibiquality(signal, signal_type, primary_detector=None, secondary_detector=None, sampling_rate=1000):
+    """**Assess quality of cardiac / cardiovascular signal by comparing beat detections from two beat detectors**
+
+    Assess the quality of a cardiac (e.g. ECG) / cardiovascular (e.g. PPG) signal. You can pass an unfiltered
+    signal as an input, but typically a filtered signal (e.g. cleaned using ``ecg_clean()`` or ``ppg_clean()``)
+    will result in more reliable results.
+
+    To do so, the algorithm (proposed in Ho et al. 2025) assesses signal quality on a beat-by-beat basis by predicting
+    whether each interbeat-interval (IBI) is accurate. To do so, beats are detected using a primary detector,
+    and each IBI is predicted to be accurate only if a secondary detector detects beats
+    in the same positions (within a tolerance). In this implementation, all signal samples within an
+    IBI are rated as high quality (1) if that IBI is predicted to be accurate, or low
+    quality (0) if that IBI is predicted to be inaccurate. This approach was derived from the previously
+    proposed bSQI approach.
+
+    Parameters
+    ----------
+    signal : Union[list, np.array, pd.Series]
+        The cleaned signal, such as that returned by ``ppg_clean()`` or ``ecg_clean()``.
+    signal_type : str
+        The signal type (e.g. "ppg" or "ecg").
+    primary_detector : str
+        The name of the primary beat detector (e.g. the defaults are ``"unsw"`` for the ECG, and ``"charlton"``
+        for the PPG).
+    secondary_detector : str
+        The name of the secondary beat detector (e.g. the defaults are ``"neurokit"`` for the ECG, and ``"elgendi"``
+        for the PPG).
+    sampling_rate : int
+        The sampling frequency of ``signal`` (in Hz, i.e., samples/second). Defaults to 1000.
+
+    Returns
+    -------
+    quality : array
+        Vector containing the quality index values: 1 for high-quality samples, 0 for low-quality samples.
+
+    See Also
+    --------
+    ecg_quality
+
+    References
+    ----------
+    * Ho, S.Y.S et al. (2025). "Accurate RR-interval extraction from single-lead, telehealth electrocardiogram signals.
+      medRxiv, 2025.03.10.25323655. https://doi.org/10.1101/2025.03.10.25323655
+    
+    Examples
+    --------
+    * **Example 1:** assessing PPG signal quality
+
+    .. ipython:: python
+
+      import neurokit2 as nk
+      
+      sampling_rate = 100
+      ppg = nk.ppg_simulate(
+          duration=30, sampling_rate=sampling_rate, heart_rate=70, motion_amplitude=1, burst_number=10, random_state=12
+      )
+      quality = nk.ppg_quality(ppg, sampling_rate=sampling_rate, method="ho2025")
+      nk.signal_plot([ppg, quality], standardize=True)  # a period is deemed to be low quality from 1200-1500 samples
+      plt.close()
+    
+    """
+
+    # Sanitize inputs
+    signal_type = signal_type.lower()  # remove capitalised letters
+    primary_detector = primary_detector.lower()  # remove capitalised letters
+    secondary_detector = secondary_detector.lower()  # remove capitalised letters
+    signal = np.asarray(signal)
+
+    # check that signal_type is either "ecg" or "ppg"
+    if signal_type not in ["ecg", "ppg"]:
+        raise ValueError("`signal_type` must be 'ecg' or 'ppg'.")
+
+    # Specify default beat detectors
+    if primary_detector is None:
+        if signal_type == "ecg":
+            primary_detector = "unsw"
+        elif signal_type == "ppg":
+            primary_detector = "charlton"
+    if secondary_detector is None:
+        if signal_type == "ecg":
+            secondary_detector = "neurokit"
+        elif signal_type == "ppg":
+            secondary_detector = "elgendi"
+
+    # Specify constants
+    tolerance_ms = 150 # tolerance window size, in milliseconds
+    tolerance_samps = int((tolerance_ms / 1000) * sampling_rate)
+
+    # Detect beats using each beat detector in turn
+    beats_primary = _signal_beats(signal, signal_type=signal_type, beat_detector=primary_detector, sampling_rate=sampling_rate)
+    beats_secondary = _signal_beats(signal, signal_type=signal_type, beat_detector=secondary_detector, sampling_rate=sampling_rate)
+    
+    # Filter closely spaced beats to keep only the highest amplitude beat
+    beats_primary = _filter_close_beats(beats_primary, signal, tolerance_samps)
+    beats_secondary = _filter_close_beats(beats_secondary, signal, tolerance_samps)
+    
+    # Build quality array
+    quality = np.zeros(len(signal), dtype=int)
+    for i in range(len(beats_primary) - 1):
+        start = beats_primary[i]
+        end = beats_primary[i + 1]
+
+        match_start = any(abs(start - s) <= tolerance_samps for s in beats_secondary)
+        match_end = any(abs(end - s) <= tolerance_samps for s in beats_secondary)
+
+        if match_start and match_end:
+            quality[start:end] = 1
+
+    return quality
+
+
+def _filter_close_beats(beats, signal, tolerance_samps):
+
+    if len(beats) == 0:
+        return []
+    
+    filtered = [beats[0]]
+    for i in range(1, len(beats)):
+        if beats[i] - filtered[-1] > tolerance_samps:
+            filtered.append(beats[i])
+        else:
+            # Keep the higher amplitude peak
+            if signal[beats[i]] > signal[filtered[-1]]:
+                filtered[-1] = beats[i]
+    
+    return filtered
+
+
+def _signal_beats(signal, signal_type, beat_detector, sampling_rate):
+
+    # Import peak-detection functions (placed here to avoid circular imports)
+    from ..ppg import ppg_peaks
+    from ..ecg import ecg_peaks
+
+    if signal_type=="ecg":
+        
+        # Detect beats in ECG signal
+        signals, info = ecg_peaks(
+            signal,
+            sampling_rate=sampling_rate,
+            method=beat_detector,
+        )
+
+        # Extract beats
+        beats = info["ECG_R_Peaks"]
+
+    elif signal_type=="ppg":
+        
+        # Detect beats in PPG signal
+        signals, info = ppg_peaks(
+            signal,
+            sampling_rate=sampling_rate,
+            method=beat_detector,
+        )
+
+        # Extract beats
+        beats = info["PPG_Peaks"]
+
+    return beats

--- a/neurokit2/signal/signal_templatequality.py
+++ b/neurokit2/signal/signal_templatequality.py
@@ -58,7 +58,7 @@ def signal_templatequality(signal, beat_inds, signal_type, sampling_rate=1000, m
     ----------
     * Orphanidou, C. et al. (2015). "Signal-quality indices for the electrocardiogram and photoplethysmogram:
       derivation and applications to wireless monitoring". IEEE Journal of Biomedical and Health Informatics, 19(3), 832-8.
-    * Sabeti E. et al. (2019). Signal quality measure for pulsatile physiological signals using morphological features: 
+    * Sabeti E. et al. (2019). Signal quality measure for pulsatile physiological signals using morphological features:
       Applications in reliability measure for pulse oximetry. Informatics in Medicine Unlocked, 16, 100222.
     * Charlton, P.H, et al. (2021). An impedance pneumography signal quality index: Design, assessment
       and application to respiratory rate monitoring. Biomedical Signal Processing and Control, 65, 102339.

--- a/neurokit2/signal/signal_templatequality.py
+++ b/neurokit2/signal/signal_templatequality.py
@@ -81,7 +81,7 @@ def signal_templatequality(signal, beat_inds, signal_type, sampling_rate=1000, m
 def _calc_template_morph(signal, beat_inds, signal_type, sampling_rate=1000):
 
     # Segment to get individual beat morphologies
-    heartbeats = signal_cyclesegment(signal, beat_inds, sampling_rate=sampling_rate)
+    heartbeats, _ = signal_cyclesegment(signal, beat_inds, sampling_rate=sampling_rate)
     
     # convert these to dataframe
     ind_morph = epochs_to_df(heartbeats).pivot(

--- a/neurokit2/signal/signal_templatequality.py
+++ b/neurokit2/signal/signal_templatequality.py
@@ -81,11 +81,8 @@ def signal_templatequality(signal, beat_inds, signal_type, sampling_rate=1000, m
 def _calc_template_morph(signal, beat_inds, signal_type, sampling_rate=1000):
 
     # Segment to get individual beat morphologies
-    if signal_type == "ppg":
-        heartbeats, _ = signal_cyclesegment(signal, beat_inds, sampling_rate=sampling_rate)
-    elif signal_type == "ecg":
-        heartbeats, _ = signal_cyclesegment(signal, beat_inds, sampling_rate=sampling_rate)
-
+    heartbeats = signal_cyclesegment(signal, beat_inds, sampling_rate=sampling_rate)
+    
     # convert these to dataframe
     ind_morph = epochs_to_df(heartbeats).pivot(
         index="Label", columns="Time", values="Signal"
@@ -94,10 +91,10 @@ def _calc_template_morph(signal, beat_inds, signal_type, sampling_rate=1000):
     ind_morph = ind_morph.sort_index()
 
     # Filter Nans
-    missing = ind_morph.T.isnull().sum().values
-    nonmissing = np.where(missing == 0)[0]
-    ind_morph = ind_morph.iloc[nonmissing, :]
-
+    valid_beats_mask = ~ind_morph.isnull().any(axis=1)
+    ind_morph = ind_morph[valid_beats_mask]
+    beat_inds = np.array(beat_inds)[valid_beats_mask.values]
+    
     # Find template pulse wave as the average pulse wave shape
     templ_morph = ind_morph.mean()
 

--- a/neurokit2/signal/signal_templatequality.py
+++ b/neurokit2/signal/signal_templatequality.py
@@ -5,9 +5,7 @@ from ..epochs import epochs_to_df
 from ..signal import signal_interpolate, signal_cyclesegment
 
 
-def signal_quality(
-    signal, beat_inds, signal_type, sampling_rate=1000, method="templatematch"
-):
+def signal_templatequality(signal, beat_inds, signal_type, sampling_rate=1000, method="templatematch"):
     """**Assess quality of signal by comparing individual beat morphologies with a template**
 
     Assess the quality of a signal (e.g. PPG or ECG) using the specified method. You can pass an unfiltered
@@ -21,7 +19,7 @@ def signal_quality(
       (i.e. correlate exactly with it) and 0 corresponds to there being no correlation with the average beat morphology.
 
     * The ``"disimilarity"`` method (loosely based on Sabeti et al., 2019) computes a continuous index
-      of quality of the PPG or ECG signal, by calculating the level of disimilarity between each individual
+      of quality of the PPG or ECG signal, by calculating the level of disimilarity between each individual 
       beat's morphology and an average (template) beat morpholoy (after they are normalised). A value of
       zero indicates no disimilarity (i.e. equivalent beat morphologies), whereas values above or below
       indicate increasing disimilarity. The original method used dynamic time-warping to align the pulse
@@ -36,7 +34,7 @@ def signal_quality(
     beat_inds : tuple or list
         The list of beat samples (e.g. PPG or ECG peaks returned by ``ppg_peaks()`` or ``ecg_peaks()``).
     signal_type : str
-        The signal type (e.g. 'ppg' or 'ecg').
+        The signal type (e.g. "ppg" or "ecg").
     sampling_rate : int
         The sampling frequency of ``signal`` (in Hz, i.e., samples/second). Defaults to 1000.
     method : str
@@ -59,7 +57,7 @@ def signal_quality(
     ----------
     * Orphanidou, C. et al. (2015). "Signal-quality indices for the electrocardiogram and photoplethysmogram:
       derivation and applications to wireless monitoring". IEEE Journal of Biomedical and Health Informatics, 19(3), 832-8.
-    * Sabeti E. et al. (2019). Signal quality measure for pulsatile physiological signals using morphological features:
+    * Sabeti E. et al. (2019). Signal quality measure for pulsatile physiological signals using morphological features: 
       Applications in reliability measure for pulse oximetry. Informatics in Medicine Unlocked, 16, 100222.
     """
 
@@ -68,21 +66,14 @@ def signal_quality(
     # Run selected quality assessment method
     if method in ["templatematch"]:  # Based on the approach in Orphanidou et al. (2015)
         quality = _quality_templatematch(
-            signal,
-            beat_inds=beat_inds,
-            signal_type=signal_type,
-            sampling_rate=sampling_rate,
+            signal, beat_inds=beat_inds, signal_type=signal_type, sampling_rate=sampling_rate,
         )
     elif method in ["disimilarity"]:  # Based on the approach in Sabeti et al. (2019)
         quality = _quality_disimilarity(
-            signal,
-            beat_inds=beat_inds,
-            signal_type=signal_type,
-            sampling_rate=sampling_rate,
+            signal, beat_inds=beat_inds, signal_type=signal_type, sampling_rate=sampling_rate
         )
 
     return quality
-
 
 # =============================================================================
 # Calculate template morphology
@@ -90,7 +81,10 @@ def signal_quality(
 def _calc_template_morph(signal, beat_inds, signal_type, sampling_rate=1000):
 
     # Segment to get individual beat morphologies
-    heartbeats = signal_cyclesegment(signal, beat_inds, sampling_rate)
+    if signal_type == "ppg":
+        heartbeats, _ = signal_cyclesegment(signal, beat_inds, sampling_rate=sampling_rate)
+    elif signal_type == "ecg":
+        heartbeats, _ = signal_cyclesegment(signal, beat_inds, sampling_rate=sampling_rate)
 
     # convert these to dataframe
     ind_morph = epochs_to_df(heartbeats).pivot(
@@ -100,44 +94,39 @@ def _calc_template_morph(signal, beat_inds, signal_type, sampling_rate=1000):
     ind_morph = ind_morph.sort_index()
 
     # Filter Nans
-    valid_beats_mask = ~ind_morph.isnull().any(axis=1)
-    ind_morph = ind_morph[valid_beats_mask]
-    beat_inds = np.array(beat_inds)[valid_beats_mask.values]
+    missing = ind_morph.T.isnull().sum().values
+    nonmissing = np.where(missing == 0)[0]
+    ind_morph = ind_morph.iloc[nonmissing, :]
 
     # Find template pulse wave as the average pulse wave shape
-    templ_pw = ind_morph.mean()
+    templ_morph = ind_morph.mean()
 
-    return templ_pw, ind_morph, beat_inds
+    return templ_morph, ind_morph, beat_inds
 
 
 # =============================================================================
 # Quality assessment using template-matching method
 # =============================================================================
-def _quality_templatematch(
-    signal, beat_inds=None, signal_type="ppg", sampling_rate=1000
-):
+def _quality_templatematch(signal, beat_inds=None, signal_type="ppg", sampling_rate=1000):
 
     # Obtain individual beat morphologies and template beat morphology
     templ_morph, ind_morph, beat_inds = _calc_template_morph(
-        signal,
-        beat_inds=beat_inds,
-        signal_type=signal_type,
-        sampling_rate=sampling_rate,
-    )
-
+            signal, beat_inds=beat_inds, signal_type=signal_type, sampling_rate=sampling_rate
+        )
+    
     # Find correlation coefficients (CCs) between individual beat morphologies and the template
-    cc = np.zeros(len(beat_inds) - 1)
-    for beat_no in range(0, len(beat_inds) - 1):
-        temp = np.corrcoef(ind_morph.iloc[beat_no], templ_morph)
-        cc[beat_no] = temp[0, 1]
+    cc = np.zeros(ind_morph.shape[0])
+    for i in range(ind_morph.shape[0]):
+        temp = np.corrcoef(ind_morph.iloc[i], templ_morph)
+        cc[i] = temp[0, 1]
+    beat_inds_for_cc = beat_inds[ind_morph.index.to_numpy() - 1]
 
     # Interpolate beat-by-beat CCs
     quality = signal_interpolate(
-        beat_inds[0:-1], cc, x_new=np.arange(len(signal)), method="previous"
+        beat_inds_for_cc, cc, x_new=np.arange(len(signal)), method="previous"
     )
 
     return quality
-
 
 # =============================================================================
 # Disimilarity measure method
@@ -148,10 +137,9 @@ def _norm_sum_one(pw):
     pw = pw - pw.min() + 1
 
     # normalise pulse wave to sum to one
-    pw = pw / np.sum(pw)
+    pw = [x / sum(pw) for x in pw]
 
     return pw
-
 
 def _calc_dis(pw1, pw2):
     # following the methodology in https://doi.org/10.1016/j.imu.2019.100222 (Sec. 3.1.2.5)
@@ -163,7 +151,7 @@ def _calc_dis(pw1, pw2):
     # normalise to sum to one
     pw1 = _norm_sum_one(pw1)
     pw2 = _norm_sum_one(pw2)
-
+    
     # ignore any elements which are zero because log(0) is -inf
     rel_els = (pw1 != 0) & (pw2 != 0)
 
@@ -172,30 +160,25 @@ def _calc_dis(pw1, pw2):
 
     return dis
 
-
 # =============================================================================
 # Quality assessment using disimilarity method
 # =============================================================================
-def _quality_disimilarity(
-    signal, beat_inds=None, signal_type="ppg", sampling_rate=1000
-):
+def _quality_disimilarity(signal, beat_inds=None, signal_type="ppg", sampling_rate=1000):
 
     # Obtain individual beat morphologies and template beat morphology
     templ_morph, ind_morph, beat_inds = _calc_template_morph(
-        signal,
-        beat_inds=beat_inds,
-        signal_type=signal_type,
-        sampling_rate=sampling_rate,
-    )
-
+            signal, beat_inds=beat_inds, signal_type=signal_type, sampling_rate=sampling_rate
+        )
+    
     # Find individual disimilarity measures
-    dis = np.zeros(len(beat_inds) - 1)
-    for beat_no in range(0, len(beat_inds) - 1):
-        dis[beat_no] = _calc_dis(ind_morph.iloc[beat_no], templ_morph)
+    dis = np.zeros(ind_morph.shape[0])
+    for i in range(ind_morph.shape[0]):
+        dis[i] = _calc_dis(ind_morph.iloc[i], templ_morph)
+    beat_inds_for_dis = beat_inds[ind_morph.index.to_numpy() - 1]
 
     # Interpolate beat-by-beat dis's
     quality = signal_interpolate(
-        beat_inds[0:-1], dis, x_new=np.arange(len(signal)), method="previous"
+        beat_inds_for_dis, dis, x_new=np.arange(len(signal)), method="previous"
     )
 
     return quality

--- a/neurokit2/signal/signal_templatequality.py
+++ b/neurokit2/signal/signal_templatequality.py
@@ -134,7 +134,7 @@ def _norm_sum_one(pw):
     pw = pw - pw.min() + 1
 
     # normalise pulse wave to sum to one
-    pw = [x / sum(pw) for x in pw]
+    pw = pw / np.sum(pw)
 
     return pw
 

--- a/neurokit2/signal/signal_templatequality.py
+++ b/neurokit2/signal/signal_templatequality.py
@@ -6,17 +6,18 @@ from ..signal import signal_interpolate, signal_cyclesegment
 
 
 def signal_templatequality(signal, beat_inds, signal_type, sampling_rate=1000, method="templatematch"):
-    """**Assess quality of signal by comparing individual beat morphologies with a template**
+    """**Assess quality of signal by comparing individual beat (or breath) morphologies with a template**
 
-    Assess the quality of a signal (e.g. PPG or ECG) using the specified method. You can pass an unfiltered
-    signal as an input, but typically a filtered signal (e.g. cleaned using ``ppg_clean()`` or ``ecg_clean()``) will result in
-    more reliable results. The following methods are available:
+    Assess the quality of a signal (e.g. PPG, ECG or RSP) using the specified method. You can pass an unfiltered
+    signal as an input, but typically a filtered signal (e.g. cleaned using ``ppg_clean()``, ``ecg_clean()``, or
+    ``rsp_clean()``) will result in more reliable results. The following methods are available:
 
-    * The ``"templatematch"`` method (loosely based on Orphanidou et al., 2015) computes a continuous
-      index of quality of the PPG or ECG signal, by calculating the correlation coefficient between each
-      individual beat's morphology and an average (template) beat morphology. This index is therefore
-      relative: 1 corresponds to a signal where each individual beat's morphology is closest to the average beat morphology
-      (i.e. correlate exactly with it) and 0 corresponds to there being no correlation with the average beat morphology.
+    * The ``"templatematch"`` method (loosely based on Orphanidou et al., 2015 and Charlton et al., 2021) computes a
+      continuous index of quality of the PPG, ECG or RSP signal, by calculating the correlation coefficient between each
+      individual beat's (or breath's) morphology and an average (template) beat morphology. This index is therefore
+      relative: 1 corresponds to a signal where each individual beat's (or breath's) morphology is closest to the average
+      beat (or breath) morphology (i.e. correlate exactly with it) and 0 corresponds to there being no correlation with
+      the average beat (or breath) morphology.
 
     * The ``"disimilarity"`` method (loosely based on Sabeti et al., 2019) computes a continuous index
       of quality of the PPG or ECG signal, by calculating the level of disimilarity between each individual 
@@ -34,7 +35,7 @@ def signal_templatequality(signal, beat_inds, signal_type, sampling_rate=1000, m
     beat_inds : tuple or list
         The list of beat samples (e.g. PPG or ECG peaks returned by ``ppg_peaks()`` or ``ecg_peaks()``).
     signal_type : str
-        The signal type (e.g. "ppg" or "ecg").
+        The signal type (e.g. "ppg", "ecg", or "rsp").
     sampling_rate : int
         The sampling frequency of ``signal`` (in Hz, i.e., samples/second). Defaults to 1000.
     method : str
@@ -59,12 +60,14 @@ def signal_templatequality(signal, beat_inds, signal_type, sampling_rate=1000, m
       derivation and applications to wireless monitoring". IEEE Journal of Biomedical and Health Informatics, 19(3), 832-8.
     * Sabeti E. et al. (2019). Signal quality measure for pulsatile physiological signals using morphological features: 
       Applications in reliability measure for pulse oximetry. Informatics in Medicine Unlocked, 16, 100222.
+    * Charlton, P.H, et al. (2021). An impedance pneumography signal quality index: Design, assessment
+      and application to respiratory rate monitoring. Biomedical Signal Processing and Control, 65, 102339.
     """
 
     signal_type = signal_type.lower()  # remove capitalised letters
 
     # Run selected quality assessment method
-    if method in ["templatematch"]:  # Based on the approach in Orphanidou et al. (2015)
+    if method in ["templatematch"]:  # Based on the approach in Orphanidou et al. (2015) and Charlton et al. (2021)
         quality = _quality_templatematch(
             signal, beat_inds=beat_inds, signal_type=signal_type, sampling_rate=sampling_rate,
         )


### PR DESCRIPTION
# Description

This PR aims to add a new quality assessment method for ECG and PPG signals. Briefly, this method assesses signal quality by comparing beat detections from two beat detectors. It outputs a quality array containing 0s (low quality) and 1s (high), where each detected interbeat interval (IBI) is deemed to be either low or high quality.

# Proposed Changes

- I added a `signal_ibiquality()` function, which is suitable for use with ECG and PPG signals
- I updated `ppg_quality()` and `ecg_quality` with this new quality assessment method. When the method is selected, these functions now call `signal_ibiquality`.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [X] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [X] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)

# Notes
This builds on the changes made in [PR1129](https://github.com/neuropsychology/NeuroKit/pull/1129) and [PR1130](https://github.com/neuropsychology/NeuroKit/pull/1130).