### PR TITLE
[Fix] Make Sure data()'s proj_id is Int or None

### DIFF
--- a/neurokit2/data/data.py
+++ b/neurokit2/data/data.py
@@ -4,7 +4,9 @@ import os
 import pickle
 import urllib
 
+import numpy as np
 import pandas as pd
+
 from sklearn import datasets as sklearn_datasets
 
 
@@ -194,9 +196,7 @@ def data(dataset="bio_eventrelated_100hz"):
     # Dataframes ===============================
     if dataset == "iris":
         info = sklearn_datasets.load_iris()
-        data = pd.DataFrame(
-            info.data, columns=["Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"]
-        )
+        data = pd.DataFrame(info.data, columns=["Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"])
         data["Species"] = info.target_names[info.target]
         return data
 
@@ -224,12 +224,15 @@ def data(dataset="bio_eventrelated_100hz"):
 
     # TODO: Add more EEG (fif and edf datasets)
     if dataset in ["eeg_1min_200hz"]:
+        url = "https://github.com/neuropsychology/NeuroKit/blob/dev/data/eeg_1min_200hz.pickle?raw=true"
+        with urllib.request.urlopen(url) as response:
+            raw = pickle.load(response)
 
-        return pickle.load(
-            urllib.request.urlopen(
-                "https://github.com/neuropsychology/NeuroKit/blob/dev/data/eeg_1min_200hz.pickle?raw=true"
-            )
-        )
+        # Fix for MNE compatibility
+        if hasattr(raw.info, "proj_id") and isinstance(raw.info.proj_id, np.ndarray) and raw.info.proj_id.size == 1:
+            raw.info["proj_id"] = int(raw.info.proj_id[0])
+        else:
+            raw.info.proj_id = None
 
     # General case
     file, ext = os.path.splitext(dataset)  # pylint: disable=unused-variable

--- a/neurokit2/data/data.py
+++ b/neurokit2/data/data.py
@@ -228,11 +228,11 @@ def data(dataset="bio_eventrelated_100hz"):
         with urllib.request.urlopen(url) as response:
             raw = pickle.load(response)
 
-        # Fix for MNE compatibility
         if hasattr(raw.info, "proj_id") and isinstance(raw.info.proj_id, np.ndarray) and raw.info.proj_id.size == 1:
             raw.info["proj_id"] = int(raw.info.proj_id[0])
-        else:
+        elif not hasattr(raw.info, "proj_id") or not isinstance(raw.info.proj_id, int):
             raw.info.proj_id = None
+        return raw
 
     # General case
     file, ext = os.path.splitext(dataset)  # pylint: disable=unused-variable


### PR DESCRIPTION
# Description

Makes sure proj_id is int or None type. This shoudl fix the fact that building the docs (running "make html") gets stuck on an eeg notebook (examples/eeg_complexity/eeg_complexity.ipynb) that imports a dataset where the proj_id shows up initially as a numpy array.

Here is the [error.log](https://github.com/user-attachments/files/21498930/error.log) that leads me to believe this fix is necessary.


# Additional Proposed Changes

I have changed a call of open to with, at the point when the function interfaces with files, based on this feedback from running the code checks: "data.py:228:12: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)".


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [X] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [X] My PR is targeted at the **dev branch** (and not towards the master branch).
- [X] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)

I believe the last item on the checklist is not applicable.