### PR TITLE
[Improvement] Speeding up UNSW QRS detector

### DIFF
--- a/neurokit2/ecg/ecg_findpeaks.py
+++ b/neurokit2/ecg/ecg_findpeaks.py
@@ -321,14 +321,11 @@ def _ecg_findpeaks_neurokit(
     peaks = np.asarray(peaks).astype(int)  # Convert to int
     return peaks
 
+
 # =============================================================================
 # Kahmis
 # =============================================================================
-def _ecg_findpeaks_khamis(
-    signal,
-    sampling_rate=1000,
-    **kwargs
-):
+def _ecg_findpeaks_khamis(signal, sampling_rate=1000, **kwargs):
     """UNSW QRS detection algorithm, developed by Khamis et al. (2016).
     Designed for both clinical ECGs and poorer quality telehealth ECGs.
     Adapted from the original MATLAB implementation by Khamis et al. (available under a CC0 licence).
@@ -468,7 +465,7 @@ def _ecg_findpeaks_khamis(
 
         smashedECG = []
         for i in range(len(starts)):
-            smashedECG.append(ECG[starts[i]:ends[i] + 1])
+            smashedECG.append(ECG[starts[i] : ends[i] + 1])
 
         return smashedECG
 
@@ -482,7 +479,7 @@ def _ecg_findpeaks_khamis(
             # Number of 2s windows (P) in data rounded up
             P = int(np.ceil(len(x) / (2 * fs)))
             y = np.zeros(2 * fs * P)
-            y[:len(x)] = x
+            y[: len(x)] = x
             y = y.reshape((P, 2 * fs))
 
             y = y - np.mean(y, axis=1, keepdims=True)  # Center the data
@@ -507,9 +504,14 @@ def _ecg_findpeaks_khamis(
 
         return F
 
-    def sortfilt1(x, n, p, use_original_percentile_filter=False):
-
-        N = len(x)
+    def sortfilt1(x, n, p):
+        # Replaces the original MATLAB-style loop that manually sorted a sliding
+        # window and picked the P-th element. scipy.ndimage.percentile_filter is
+        # equivalent in the interior of the signal; the only differences are at
+        # the boundaries (first/last ~n//2 samples) where `mode='nearest'` pads
+        # with the edge value instead of shrinking the window. This has little
+        # practical impact on peak detection because peaks are rarely expected at
+        # the very edges of the recording.
 
         if p > 100:
             p = 100
@@ -523,27 +525,8 @@ def _ecg_findpeaks_khamis(
             N1 = int((n - 1) / 2)
             N2 = int((n - 1) / 2)
 
-        y = np.zeros_like(x)
-
-        if use_original_percentile_filter:
-            
-            # use percentile filter implementation from original matlab code
-            y = np.zeros(N)
-            for i in range(1, N + 1):
-                A = max(1, i - N1)
-                B = min(N, i + N2)
-                P = 1 + round((p / 100) * (B - A))
-                Z = np.sort(x[A - 1:B])
-                y[i - 1] = Z[P - 1]
-
-        else:
-            # use scipy's percentile filter
-            # Calculate window size from N1 and N2
-            size = N1 + N2 + 1  # total length of the window
-            # Apply the percentile filter
-            y = percentile_filter(x, percentile=p, size=size, mode='nearest')
-
-        return y
+        size = N1 + N2 + 1
+        return percentile_filter(x, percentile=p, size=size, mode="nearest")
 
     def myfiltfilt(b, a, x):
 
@@ -554,9 +537,8 @@ def _ecg_findpeaks_khamis(
 
         return y
 
-
     # Bandpass filtering
-    def cleansignal(x, fs, do_original_filtering = False):
+    def cleansignal(x, fs, do_original_filtering=False):
         # cleansignal
         # Helper function:
         # baseline removal then high pass (0.7 Hz) filtering
@@ -576,22 +558,24 @@ def _ecg_findpeaks_khamis(
 
         # hpf - used to eliminate dc component or low frequency drift.
         if do_original_filtering:
-            b, a = scipy.signal.butter(7, 0.7 / (fs / 2), btype='high')
+            b, a = scipy.signal.butter(7, 0.7 / (fs / 2), btype="high")
             hpdata = myfiltfilt(b, a, meddata)
         else:
-            sos = scipy.signal.butter(7, 0.7 / (fs / 2), btype='high', output='sos')
+            sos = scipy.signal.butter(7, 0.7 / (fs / 2), btype="high", output="sos")
             hpdata = scipy.signal.sosfiltfilt(sos, meddata)
 
         # low pass linear phase filter
-        b, a = scipy.signal.butter(7, 20 / (fs / 2), btype='low')
+        b, a = scipy.signal.butter(7, 20 / (fs / 2), btype="low")
         lphpdata = myfiltfilt(b, a, hpdata)
 
         return lphpdata
 
     if sampling_rate < 50:
-        raise Exception('This function requires a sampling rate of at least 50 Hz')
+        raise Exception("This function requires a sampling rate of at least 50 Hz")
 
-    finalmask = []  # The original MATLAB implementation allowed a mask to optionally be inputted.
+    finalmask = (
+        []
+    )  # The original MATLAB implementation allowed a mask to optionally be inputted.
 
     # Clean up Signal - hi pass, then low pass filter
     lphpdata = cleansignal(signal, sampling_rate)
@@ -603,7 +587,7 @@ def _ecg_findpeaks_khamis(
     # Sort filter
     top = sortfilt1(lphpdata, round(sampling_rate * 0.1), 100)
     bot = sortfilt1(lphpdata, round(sampling_rate * 0.1), 0)
-    envelope = (top - bot)
+    envelope = top - bot
     envelope[envelope < 0] = 0
     feature = np.abs(diffdata * envelope)
 
@@ -617,8 +601,8 @@ def _ecg_findpeaks_khamis(
     diffpower1 = np.abs(scipy.signal.filtfilt(b, a, feature)) ** 0.5
 
     smashedSig = smashECG(diffpower1, finalmask)
-    F = smashedFFT(smashedSig, sampling_rate, 2 ** 14)
-    f = np.arange(0, 2 ** 13) * sampling_rate / 2 ** 14
+    F = smashedFFT(smashedSig, sampling_rate, 2**14)
+    f = np.arange(0, 2**13) * sampling_rate / 2**14
     range_indices = np.where((f >= 0.1) & (f < 4))[0]
     max_idx = np.argmax(F[range_indices])
     fftHRfreq = f[range_indices[max_idx]]
@@ -626,7 +610,9 @@ def _ecg_findpeaks_khamis(
     # Update smoother feature signal
     HRmin = 1.5  # Hz: 90 BPM  (don't want to go much below this, will miss ectopics otherwise!)
     HRmax = 4.0  # Hz: 240 BPM  (Shouldn't see much above this)
-    fc = np.median(2 * np.array([HRmin, fftHRfreq, HRmax]))  # Kills half of second harmonic and all of the rest
+    fc = np.median(
+        2 * np.array([HRmin, fftHRfreq, HRmax])
+    )  # Kills half of second harmonic and all of the rest
     k = ((sampling_rate / 2) * 0.0037) / fc
     Nh = round(k * sampling_rate)  # Heuristic for Hamming window 3dB point
     b = scipy.signal.windows.hamming(Nh, sym=True)
@@ -640,7 +626,14 @@ def _ecg_findpeaks_khamis(
     # Find valid indices
     valididx = np.setdiff1d(np.arange(len(diffpower2)), finalmask)
     # Maximum filter to get upper envelope
-    Wsort = round(np.median(2 * np.array([sampling_rate, sampling_rate / fftHRfreq, sampling_rate / HRmax])))
+    Wsort = round(
+        np.median(
+            2
+            * np.array(
+                [sampling_rate, sampling_rate / fftHRfreq, sampling_rate / HRmax]
+            )
+        )
+    )
     upperenv = sortfilt1(diffpower2, Wsort, 100)  # Morph Open
     upperenv = sortfilt1(upperenv, Wsort, 0)  # Morph Close
     lowerenv = sortfilt1(diffpower2, Wsort, 0)  # Morph Open
@@ -656,10 +649,12 @@ def _ecg_findpeaks_khamis(
     tpsidx = turning_points(diffpower2, threshold)
     qrs = tpsidx[tpsidx > 0]
     qrs = np.setdiff1d(qrs, finalmask)
-    m_rr, rr_list, n_rr, n_sections = calculate_rr_interval(qrs, finalmask, sampling_rate)
+    m_rr, rr_list, n_rr, n_sections = calculate_rr_interval(
+        qrs, finalmask, sampling_rate
+    )
 
     # Stop if no qrs waves were detected (not in original matlab algorithm):
-    if len(qrs)==0:
+    if len(qrs) == 0:
         peaks = np.asarray(qrs).astype(int)  # Convert to int
         return peaks
 
@@ -676,21 +671,23 @@ def _ecg_findpeaks_khamis(
     temp = np.zeros(len(diffpower2) + 2)
     temp[newmask + 1] = 1
     temp = np.concatenate(([1], temp, [1]))
-    
+
     # Fill in sections less than 1.5*mRR seconds;
 
     for i in range(1, len(temp)):
         if temp[i] - temp[i - 1] == -1:
             start = i
         if temp[i] - temp[i - 1] == 1 and (i - 1) - start < 1.5 * m_rr:
-            temp[start:(i - 1)] = 1
+            temp[start : (i - 1)] = 1
     newmask = np.where(temp[1:-1] == 1)[0]
 
     # Only keep newly found QRS between long beats
     qrs2 = np.setdiff1d(qrs2, newmask)
     # Add them to the old QRS (found using low sensitivity)
     qrs = np.union1d(qrs, qrs2)
-    m_rr, rr_list, n_rr, n_sections = calculate_rr_interval(qrs, finalmask, sampling_rate)
+    m_rr, rr_list, n_rr, n_sections = calculate_rr_interval(
+        qrs, finalmask, sampling_rate
+    )
 
     # 3rd pass: Highest threshold
     # Back-track to remove possible wrong beats


### PR DESCRIPTION
# Description

This PR aims to speed up the UNSW QRS detector (_i.e._ the "khamis2016" method in `ecg_findpeaks.py`).

# Proposed Changes

I changed the `sortfilt1()` function to:

- Create two ways to perform percentile filtering: (i) the original percentile filter, which was coded from scratch using a for loop in the original code; and (ii) scipy's `percentile filter`, from `scipy.ndimage`.
- Accept an additional input function named `use_original_percentile_filter`, with a default value of `False`, which determines how the percentile filtering is performed.

I am hopeful that these are equivalent, and that with this change the code retains the same functionality, but is significantly faster when using the `scipy` filtering.

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
