### PR TITLE
Modify basSQI scaling and power ratio calculation

### DIFF
--- a/neurokit2/ecg/ecg_quality.py
+++ b/neurokit2/ecg/ecg_quality.py
@@ -384,7 +384,7 @@ def _ecg_quality_zhao2018(
         if V < 1.5:
             return "Excellent"
         elif V >= 2.40:
-            return "Unnacceptable"
+            return "Unacceptable"
         else:
             return "Barely acceptable"
 


### PR DESCRIPTION
**Describe the bug**
This PR addresses two distinct bugs regarding the `basSQI` calculation in `ecg_quality.py`: a mathematical typo replicating a published error, and a unit mismatch between evaluation modes. This directly resolves the issues raised in #869 regarding `basSQI` returning values > 100.

**1. The Mathematical Typo in `_ecg_quality_basSQI`**
Currently, the function returns `(1 - num_power) / dem_power`. This faithfully replicates a typesetting error printed in Equation 11 of the original [Zhao et al. (2018)](https://www.frontiersin.org/journals/physiology/articles/10.3389/fphys.2018.00727/full) manuscript. 
Proof of the typo exists in the authors' own text immediately below the equation: *"If no baseline drift interference is noted, the basSQI value is close to 1."*
* **Current Code:** `(1 - 0) / 0.005 = 200` (Fails the definition).
* **Corrected Math:** `1 - (0 / 0.005) = 1` (Matches the definition).

**2. The Unit Mismatch in `_ecg_quality_zhao2018`**
The Zhao et al. (2018) methodology shifts units depending on the logic applied. The simple logic thresholds evaluate `basSQI` as a 0-1 decimal. However, the fuzzy logic membership functions (Equations 30-32) scale the baseline variable to a 0-100 percentage. 
Currently, passing the decimal ratio into `mode="fuzzy"` shatters the Cauchy distribution bounds (which check `if basSQI <= 90:`). 

**Proposed Fixes**
1. **Fix the equation in `_ecg_quality_basSQI`:**
Change: `return (1 - num_power) / dem_power`
To: `return 1 - (num_power / dem_power)`

2. **Fix the unit scaling in `_ecg_quality_zhao2018`:**
Add a localized conversion strictly inside the fuzzy block so `mode="simple"` is not affected.
```python
    # UbH
    basSQI = basSQI * 100
    if basSQI <= 90:
        ...