### PR TITLE
[Fix] releasePR to include testpypi environment (3)

### DIFF
--- a/.github/workflows/releasePR.yml
+++ b/.github/workflows/releasePR.yml
@@ -24,13 +24,16 @@ jobs:
     publish-test:
         name: 🧪 Publish to TestPyPI
         needs: build
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         runs-on: ubuntu-latest
         environment:
             name: testpypi
             url: https://test.pypi.org/p/neurokit2
         steps:
             - uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+
             - uses: astral-sh/setup-uv@v5
 
             - name: Build
@@ -47,13 +50,16 @@ jobs:
     publish-prod:
         name: 🚀 Publish to PyPI
         needs: publish-test
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         runs-on: ubuntu-latest
         environment:
             name: pypi
             url: https://pypi.org/p/neurokit2
         steps:
             - uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+
             - uses: astral-sh/setup-uv@v5
 
             - name: Build


### PR DESCRIPTION
I think the current error is that the testpypi does not have an environment either. Sorry all this trouble comes from me changing from github secrets to the more modern OIDC approach.

I think you need to also double check both pypi.org and test.pypi.org publishing settings and make sure that the environment exists. Also the github repo settings that both environments also exist etc.


Also, are you sure you want to push both to the testing server and the real server at the same time? I am also unsure if the dynamic versioning will work 100% since I had it before that the actual release happens on tag upload and would take the name of the tag.

We could maybe have the following for testing:

```yaml
if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
```

and the following for the publish:
```yaml
if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
```

With the tags, it automatically gets the new version number based on the tag and runs the CI on each tag (also with `tags: ['v*']` in the on push). Also it would upload to the test pypi when pushing to master with a `dev` versioning system and then overwrite that with the actual new version when the tag is created