### PR TITLE
Safeguards to avoid crashing when using external R peaks 

### DIFF
--- a/neurokit2/ecg/ecg_delineate.py
+++ b/neurokit2/ecg/ecg_delineate.py
@@ -763,7 +763,7 @@ def _calc_prominence(peaks, sig, Rpeak=None, minima=False):
     _sig = -sig if minima else sig
     w[peaks] = scipy.signal.peak_prominences(_sig, peaks)[0]
     # optional: set rpeak prominence to zero to emphasize other peaks
-    if Rpeak is not None:
+    if Rpeak is not None and Rpeak < len(w):
         w[Rpeak] = 0
     return w
 

--- a/neurokit2/ecg/ecg_delineate.py
+++ b/neurokit2/ecg/ecg_delineate.py
@@ -763,7 +763,7 @@ def _calc_prominence(peaks, sig, Rpeak=None, minima=False):
     _sig = -sig if minima else sig
     w[peaks] = scipy.signal.peak_prominences(_sig, peaks)[0]
     # optional: set rpeak prominence to zero to emphasize other peaks
-    if Rpeak is not None and Rpeak < len(w):
+    if Rpeak is not None and 0 <= Rpeak < len(w):
         w[Rpeak] = 0
     return w
 
@@ -781,9 +781,9 @@ def _prominence_find_s_wave(sig, weight_minima, current_wave, max_qrs_interval):
     if "ECG_Q_Peaks" not in current_wave:
         return
     s_bound = current_wave["ECG_Q_Peaks"] + max_qrs_interval
-    s_wave = np.argmax(weight_minima[current_wave["ECG_R_Peaks"] : s_bound] > 0) + current_wave["ECG_R_Peaks"]
     if len(weight_minima[current_wave["ECG_R_Peaks"] : s_bound] > 0) == 0:
         return
+    s_wave = np.argmax(weight_minima[current_wave["ECG_R_Peaks"] : s_bound] > 0) + current_wave["ECG_R_Peaks"]
     current_wave["ECG_S_Peaks"] = (
         np.argmin(sig[current_wave["ECG_R_Peaks"] : s_bound]) + current_wave["ECG_R_Peaks"]
         if s_wave == current_wave["ECG_R_Peaks"]

--- a/neurokit2/ecg/ecg_delineate.py
+++ b/neurokit2/ecg/ecg_delineate.py
@@ -772,7 +772,8 @@ def _prominence_find_q_wave(weight_minima, current_wave, max_r_rise_time):
     if "ECG_R_Peaks" not in current_wave:
         return
     q_bound = max(current_wave["ECG_R_Peaks"] - max_r_rise_time, 0)
-
+    if len(weight_minima[q_bound : current_wave["ECG_R_Peaks"]]) == 0:
+        return
     current_wave["ECG_Q_Peaks"] = np.argmax(weight_minima[q_bound : current_wave["ECG_R_Peaks"]]) + q_bound
 
 
@@ -781,6 +782,8 @@ def _prominence_find_s_wave(sig, weight_minima, current_wave, max_qrs_interval):
         return
     s_bound = current_wave["ECG_Q_Peaks"] + max_qrs_interval
     s_wave = np.argmax(weight_minima[current_wave["ECG_R_Peaks"] : s_bound] > 0) + current_wave["ECG_R_Peaks"]
+    if len(weight_minima[current_wave["ECG_R_Peaks"] : s_bound] > 0) == 0:
+        return
     current_wave["ECG_S_Peaks"] = (
         np.argmin(sig[current_wave["ECG_R_Peaks"] : s_bound]) + current_wave["ECG_R_Peaks"]
         if s_wave == current_wave["ECG_R_Peaks"]


### PR DESCRIPTION
Three checks to avoid crashing when sending external R peaks to delineate the ECG