### PR TITLE
[Fix] Read acqknowledge now tries to convert sample rate to int

### DIFF
--- a/neurokit2/data/read_acqknowledge.py
+++ b/neurokit2/data/read_acqknowledge.py
@@ -8,6 +8,7 @@ import pandas as pd
 from ..misc import NeuroKitWarning
 from ..signal import signal_resample
 
+
 def read_acqknowledge(filename, sampling_rate="max", resample_method="interpolation", impute_missing=True):
     """**Read and format a BIOPAC's AcqKnowledge file into a pandas' dataframe**
 

--- a/neurokit2/data/read_acqknowledge.py
+++ b/neurokit2/data/read_acqknowledge.py
@@ -5,8 +5,8 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 
-from ..signal import signal_resample
 from ..misc import NeuroKitWarning
+from ..signal import signal_resample
 
 def read_acqknowledge(filename, sampling_rate="max", resample_method="interpolation", impute_missing=True):
     """**Read and format a BIOPAC's AcqKnowledge file into a pandas' dataframe**

--- a/neurokit2/data/read_acqknowledge.py
+++ b/neurokit2/data/read_acqknowledge.py
@@ -84,9 +84,9 @@ def read_acqknowledge(filename, sampling_rate="max", resample_method="interpolat
         else:
             sampling_rate = max_freq
             warn(
-                f"Automatic sampling rate conversion to int failed"
-                f"Sampling rate is {sampling_rate}, of type {type(sampling_rate)}"
-                f"This may cause errors or unexpected behaviours of other neurokit functions",
+                f"Automatic sampling rate conversion to int failed.\n"
+                f"Sampling rate is {sampling_rate}, of type {type(sampling_rate)},\n"
+                f"This may cause errors or unexpected behaviours of other neurokit functions.",
                 category=NeuroKitWarning,
             )
 

--- a/neurokit2/data/read_acqknowledge.py
+++ b/neurokit2/data/read_acqknowledge.py
@@ -1,11 +1,12 @@
 import os
 from collections import Counter
+from warnings import warn
 
 import numpy as np
 import pandas as pd
 
 from ..signal import signal_resample
-
+from ..misc import NeuroKitWarning
 
 def read_acqknowledge(filename, sampling_rate="max", resample_method="interpolation", impute_missing=True):
     """**Read and format a BIOPAC's AcqKnowledge file into a pandas' dataframe**
@@ -77,7 +78,17 @@ def read_acqknowledge(filename, sampling_rate="max", resample_method="interpolat
         freq_list = []
         for channel in file.named_channels:
             freq_list.append(file.named_channels[channel].samples_per_second)
-        sampling_rate = np.max(freq_list)
+        max_freq = np.max(freq_list)
+        if np.isfinite(max_freq):
+            sampling_rate = max_freq.astype(int).item()
+        else:
+            sampling_rate = max_freq
+            warn(
+                f"Automatic sampling rate conversion to int failed"
+                f"Sampling rate is {sampling_rate}, of type {type(sampling_rate)}"
+                f"This may cause errors or unexpected behaviours of other neurokit functions",
+                category=NeuroKitWarning,
+            )
 
     # Counter for checking duplicate channel names
     channel_counter = Counter()

--- a/tests/tests_data.py
+++ b/tests/tests_data.py
@@ -19,7 +19,7 @@ def test_read_acqknowledge():
 
     df, sampling_rate = nk.read_acqknowledge(os.path.join(path_data, "acqnowledge.acq"), sampling_rate="max")
     assert sampling_rate == 4000
-    assert type(sampling_rate) is int
+    assert isinstance(sampling_rate, int)
 
 
 def test_data():

--- a/tests/tests_data.py
+++ b/tests/tests_data.py
@@ -15,9 +15,11 @@ path_data = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file_
 def test_read_acqknowledge():
     df, sampling_rate = nk.read_acqknowledge(os.path.join(path_data, "acqnowledge.acq"), sampling_rate=2000)
     assert sampling_rate == 2000
+    assert type(sampling_rate) is int
 
     df, sampling_rate = nk.read_acqknowledge(os.path.join(path_data, "acqnowledge.acq"), sampling_rate="max")
     assert sampling_rate == 4000
+    assert type(sampling_rate) is int
 
 
 def test_data():

--- a/tests/tests_data.py
+++ b/tests/tests_data.py
@@ -15,7 +15,7 @@ path_data = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file_
 def test_read_acqknowledge():
     df, sampling_rate = nk.read_acqknowledge(os.path.join(path_data, "acqnowledge.acq"), sampling_rate=2000)
     assert sampling_rate == 2000
-    assert type(sampling_rate) is int
+    assert isinstance(sampling_rate, int)
 
     df, sampling_rate = nk.read_acqknowledge(os.path.join(path_data, "acqnowledge.acq"), sampling_rate="max")
     assert sampling_rate == 4000


### PR DESCRIPTION
# Description
Ensures that read_acqknowledge() returns sampling rate as a python native int, not a float. Also updates read_acqknowledge() unit test to check for typing

fixes #1182 

# Proposed Changes

Adds automated type coercion to int in read_acqknowledge
Adds a warning if this coercion fails
Updates the test for this function to check the type output


# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [x] I have added the newly added features to **News.rst** (if applicable) -na i think
