### PR TITLE
[Docs] Corrected a typo in ecg_delineate.ipynb

### DIFF
--- a/docs/examples/ecg_delineate/ecg_delineate.ipynb
+++ b/docs/examples/ecg_delineate/ecg_delineate.ipynb
@@ -286,7 +286,7 @@
    ],
    "source": [
     "# Delineate the ECG signal and visualizing all T-peaks boundaries\n",
-    "signal_peaj, waves_peak = nk.ecg_delineate(\n",
+    "signal_peak, waves_peak = nk.ecg_delineate(\n",
     "    ecg_signal, rpeaks, sampling_rate=SAMPLING_RATE, method=\"peak\", show=True, show_type=\"bounds_T\"\n",
     ")"
    ]


### PR DESCRIPTION
# Description

This PR aims at correcting the typo

# Proposed Changes

I've changed the variable name with a typo in it from `signal_peaj` to `signal_peak`

# Checklist

Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

- [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
- [x] My PR is targeted at the **dev branch** (and not towards the master branch).
- [ ] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
- [ ] I have added the newly added features to **News.rst** (if applicable)
