### PR TITLE
Fix microstate training and segmentation issues

### DIFF
--- a/neurokit2/microstates/microstates_classify.py
+++ b/neurokit2/microstates/microstates_classify.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..misc import replace
 
 
-def microstates_classify(segmentation, microstates):
+def microstates_classify(segmentation, microstates, return_order=False):
     """**Reorder (sort) the microstates (experimental)**
 
     Reorder (sort) the microstates (experimental) based on the pattern of values in the vector of
@@ -15,6 +15,9 @@ def microstates_classify(segmentation, microstates):
         Vector containing the segmentation.
     microstates : Union[np.array, dict]
         Array of microstates maps . Defaults to ``None``.
+    return_order : bool
+        If ``True``, also return the indices used to reorder the microstate maps. Defaults to
+        ``False``.
 
     Returns
     -------
@@ -45,9 +48,11 @@ def microstates_classify(segmentation, microstates):
     new_order = _microstates_sort(microstates)
     microstates = microstates[new_order]
 
-    replacement = dict(enumerate(new_order))
+    replacement = {old: new for new, old in enumerate(new_order)}
     segmentation = replace(segmentation, replacement)
 
+    if return_order is True:
+        return segmentation, microstates, new_order
     return segmentation, microstates
 
 

--- a/neurokit2/microstates/microstates_clean.py
+++ b/neurokit2/microstates/microstates_clean.py
@@ -1,9 +1,8 @@
 import numpy as np
-import pandas as pd
 
 from ..eeg import eeg_gfp
 from ..stats import standardize
-from .microstates_peaks import microstates_peaks
+from .microstates_peaks import _microstates_sanitize_eeg, microstates_peaks
 
 
 def microstates_clean(eeg, sampling_rate=None, train="gfp", standardize_eeg=True, normalize=True, gfp_method="l1", **kwargs):
@@ -62,26 +61,22 @@ def microstates_clean(eeg, sampling_rate=None, train="gfp", standardize_eeg=True
     .eeg_gfp, microstates_peaks, .microstates_segment
 
     """
-    # If MNE object
-    if isinstance(eeg, (pd.DataFrame, np.ndarray)) is False:
-        sampling_rate = eeg.info["sfreq"]
-        info = eeg.info
-        eeg = eeg.get_data()
-    else:
-        info = None
+    eeg, sampling_rate, info = _microstates_sanitize_eeg(eeg, sampling_rate=sampling_rate)
 
     # Normalization
     if standardize_eeg is True:
-        eeg = standardize(eeg, **kwargs)
+        standardize_kwargs = {key: kwargs[key] for key in ["robust", "window"] if key in kwargs}
+        eeg = standardize(eeg.T, **standardize_kwargs).T
 
     # Get GFP
-    gfp = eeg_gfp(eeg, sampling_rate=sampling_rate, normalize=normalize, method=gfp_method, **kwargs)
+    gfp_kwargs = {key: kwargs[key] for key in ["robust", "smooth"] if key in kwargs}
+    gfp = eeg_gfp(eeg, sampling_rate=sampling_rate, normalize=normalize, method=gfp_method, **gfp_kwargs)
 
     # If train is a custom of vector (assume it's the pre-computed peaks)
     if isinstance(train, (list, np.ndarray)):
-        peaks = train
+        peaks = np.asarray(train, dtype=int)
     # Find peaks in the global field power (GFP) or take a given amount of indices
     else:
-        peaks = microstates_peaks(eeg, gfp=train, sampling_rate=sampling_rate, **kwargs)
+        peaks = microstates_peaks(eeg, gfp=gfp if train == "gfp" else train, sampling_rate=sampling_rate)
 
     return eeg, peaks, gfp, info

--- a/neurokit2/microstates/microstates_findnumber.py
+++ b/neurokit2/microstates/microstates_findnumber.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from ..misc import find_knee, progress_bar
 from ..stats.cluster_quality import _cluster_quality_dispersion
+from .microstates_peaks import _microstates_sanitize_eeg
 from .microstates_segment import microstates_segment
 
 
@@ -63,12 +64,7 @@ def microstates_findnumber(eeg, n_max=12, method="GEV", clustering_method="kmod"
 
     """
     # Retrieve data
-    if isinstance(eeg, (pd.DataFrame, np.ndarray)) is False:
-        data = eeg.get_data()
-    elif isinstance(eeg, pd.DataFrame):
-        data = eeg.values
-    else:
-        data = eeg.copy()
+    data, _, _ = _microstates_sanitize_eeg(eeg)
 
     # Loop accross number and get indices of fit
     n_channel, _ = data.shape

--- a/neurokit2/microstates/microstates_peaks.py
+++ b/neurokit2/microstates/microstates_peaks.py
@@ -53,44 +53,61 @@ def microstates_peaks(eeg, gfp=None, sampling_rate=None, distance_between=0.01, 
     .eeg_gfp
 
     """
-    if isinstance(eeg, (pd.DataFrame, np.ndarray)) is False:
-        sampling_rate = eeg.info["sfreq"]
-        eeg = eeg.get_data()
-
-    if sampling_rate is None:
-        raise ValueError(
-            "NeuroKit error: microstates_peaks(): The sampling_rate is requested ",
-            "for this function to run. Please provide it as an argument.",
-        )
-
-    # If we don't want to rely on peaks but take uniformly spaced samples
-    # (used in microstates_clustering)
-    if isinstance(gfp, (int, float)):
-        if gfp <= 1:  # If fraction
-            gfp = int(gfp * len(eeg[0, :]))
-        return np.linspace(0, len(eeg[0, :]), gfp, endpoint=False, dtype=int)
+    eeg, sampling_rate, _ = _microstates_sanitize_eeg(eeg, sampling_rate=sampling_rate)
 
     # Deal with string inputs
     if isinstance(gfp, str):
-        if gfp == "all":
-            gfp = False
-        elif gfp == "gfp":
-            gfp = True
+        if gfp.lower() == "all":
+            return np.arange(eeg.shape[1])
+        if gfp.lower() == "gfp":
+            gfp = None
         else:
-            raise ValueError(
-                "The `gfp` argument was not understood.",
-            )
+            raise ValueError("The `gfp` argument was not understood.")
 
-    # If we want ALL the indices
-    if gfp is False:
-        return np.arange(len(eeg))
+    # If we don't want to rely on peaks but take uniformly spaced samples
+    # (used in microstates_clustering)
+    if isinstance(gfp, (int, float, np.integer, np.floating)) and not isinstance(gfp, (bool, np.bool_)):
+        if gfp <= 1:  # If fraction
+            gfp = int(gfp * eeg.shape[1])
+        if not float(gfp).is_integer() or gfp < 1 or gfp > eeg.shape[1]:
+            raise ValueError("The number of training samples must be between 1 and the number of timepoints.")
+        return np.linspace(0, eeg.shape[1], int(gfp), endpoint=False, dtype=int)
 
-    # if gfp is True or gfp is None:
-    gfp = eeg_gfp(eeg, **kwargs)
+    if gfp is None or gfp is True:
+        gfp = eeg_gfp(eeg, sampling_rate=sampling_rate, **kwargs)
+    else:
+        gfp = np.asarray(gfp)
+        if gfp.ndim != 1 or len(gfp) != eeg.shape[1]:
+            raise ValueError("The precomputed `gfp` must contain one value per timepoint.")
+
+    if sampling_rate is None:
+        raise ValueError(
+            "NeuroKit error: microstates_peaks(): `sampling_rate` is required when detecting GFP peaks."
+        )
 
     peaks = _microstates_peaks_gfp(gfp=gfp, sampling_rate=sampling_rate, distance_between=distance_between)
 
     return peaks
+
+
+def _microstates_sanitize_eeg(eeg, sampling_rate=None):
+    """Return EEG data as a channels-by-timepoints array."""
+    info = None
+    if isinstance(eeg, (pd.DataFrame, np.ndarray)) is False:
+        sampling_rate = eeg.info["sfreq"]
+        info = eeg.info
+        eeg = eeg.get_data()
+    elif isinstance(eeg, pd.DataFrame):
+        eeg = eeg.values
+
+    eeg = np.asarray(eeg)
+    if eeg.ndim == 3:
+        # MNE Epochs are ordered as epochs, channels, timepoints.
+        eeg = eeg.transpose(1, 0, 2).reshape(eeg.shape[1], -1)
+    if eeg.ndim != 2:
+        raise ValueError("EEG data must have shape (channels, timepoints) or (epochs, channels, timepoints).")
+
+    return eeg, sampling_rate, info
 
 
 # =============================================================================

--- a/neurokit2/microstates/microstates_peaks.py
+++ b/neurokit2/microstates/microstates_peaks.py
@@ -81,9 +81,7 @@ def microstates_peaks(eeg, gfp=None, sampling_rate=None, distance_between=0.01, 
             raise ValueError("The precomputed `gfp` must contain one value per timepoint.")
 
     if sampling_rate is None:
-        raise ValueError(
-            "NeuroKit error: microstates_peaks(): `sampling_rate` is required when detecting GFP peaks."
-        )
+        raise ValueError("NeuroKit error: microstates_peaks(): `sampling_rate` is required when detecting GFP peaks.")
 
     peaks = _microstates_peaks_gfp(gfp=gfp, sampling_rate=sampling_rate, distance_between=distance_between)
 

--- a/neurokit2/microstates/microstates_segment.py
+++ b/neurokit2/microstates/microstates_segment.py
@@ -175,7 +175,7 @@ def microstates_segment(
     """
     # Sanitize input
     data, indices, gfp, info_mne = microstates_clean(
-        eeg, train=train, sampling_rate=sampling_rate, standardize_eeg=standardize_eeg, gfp_method=gfp_method, **kwargs
+        eeg, train=train, sampling_rate=sampling_rate, standardize_eeg=standardize_eeg, gfp_method=gfp_method
     )
 
     # Run clustering algorithm

--- a/neurokit2/microstates/microstates_segment.py
+++ b/neurokit2/microstates/microstates_segment.py
@@ -173,6 +173,13 @@ def microstates_segment(
       on Biomedical Engineering.
 
     """
+    method = method.lower()
+    criterion = criterion.lower()
+    if criterion not in ["gev", "cv"]:
+        raise ValueError("`criterion` must be one of 'gev' or 'cv'.")
+    if n_runs < 1:
+        raise ValueError("`n_runs` must be at least 1.")
+
     # Sanitize input
     data, indices, gfp, info_mne = microstates_clean(
         eeg, train=train, sampling_rate=sampling_rate, standardize_eeg=standardize_eeg, gfp_method=gfp_method
@@ -187,7 +194,7 @@ def microstates_segment(
         random_state = rng.choice(n_runs * 1000, n_runs, replace=False)
 
         # Initialize values
-        gev = 0
+        gev = -np.inf
         cv = np.inf
         microstates = None
         segmentation = None
@@ -229,7 +236,7 @@ def microstates_segment(
                 if current_residual < cv:
                     microstates, segmentation, polarity = current_microstates, s, p
                     cv, gev, gev_all = current_residual, g, g_all
-                    info -= current_info
+                    info = current_info
 
     else:
         # Run clustering algorithm on subset
@@ -243,7 +250,8 @@ def microstates_segment(
         )
 
     # Reorder
-    segmentation, microstates = microstates_classify(segmentation, microstates)
+    segmentation, microstates, new_order = microstates_classify(segmentation, microstates, return_order=True)
+    gev_all = gev_all[new_order]
 
     # CLustering quality
     #    quality = cluster_quality(data, segmentation, clusters=microstates, info=info, n_random=10, sd=gfp)
@@ -268,7 +276,12 @@ def microstates_segment(
 # =============================================================================
 def _microstates_segment_runsegmentation(data, microstates, gfp, n_microstates):
     # Find microstate corresponding to each datapoint
-    activation = microstates.dot(data)
+    maps_centered = microstates - np.mean(microstates, axis=1, keepdims=True)
+    map_norms = np.linalg.norm(maps_centered, axis=1, keepdims=True)
+    map_norms[map_norms == 0] = 1
+    maps_normalized = maps_centered / map_norms
+    data_centered = data - np.mean(data, axis=0, keepdims=True)
+    activation = maps_normalized.dot(data_centered)
     segmentation = np.argmax(np.abs(activation), axis=0)
     polarity = np.sign(np.choose(segmentation, activation))
 

--- a/neurokit2/microstates/microstates_static.py
+++ b/neurokit2/microstates/microstates_static.py
@@ -192,7 +192,7 @@ def _microstates_lifetime(microstates, out=None):
     tau_dict = {s: [] for s in states}
     s = microstates[0]  # current symbol
     tau = 1.0  # current lifetime
-    for i in range(n):
+    for i in range(1, n):
         if microstates[i] == s:
             tau += 1.0
         else:

--- a/neurokit2/stats/cluster.py
+++ b/neurokit2/stats/cluster.py
@@ -145,14 +145,14 @@ def cluster(data, method="kmeans", n_clusters=2, random_state=None, optimize=Fal
 
     # ICA
     elif method in ["ica", "independent", "independent component analysis"]:
-        out = _cluster_pca(data, n_clusters=n_clusters, random_state=random_state, **kwargs)
+        out = _cluster_ica(data, n_clusters=n_clusters, random_state=random_state, **kwargs)
 
     # Mixture
     elif method in ["mixture", "mixt"]:
         out = _cluster_mixture(data, n_clusters=n_clusters, bayesian=False, random_state=random_state, **kwargs)
 
     # Frederic's AAHC
-    elif method in ["aahc_frederic", "aahc_eegmicrostates"]:
+    elif method in ["aahc", "aahc_frederic", "aahc_eegmicrostates"]:
         out = _cluster_aahc(data, n_clusters=n_clusters, random_state=random_state, **kwargs)
 
     # Bayesian
@@ -470,7 +470,12 @@ def _cluster_ica(data, n_clusters=2, random_state=None, **kwargs):
     """Independent Component Analysis (ICA) for clustering."""
     # Fit ICA
     ica = sklearn.decomposition.FastICA(
-        n_components=n_clusters, algorithm="parallel", whiten=True, fun="exp", random_state=random_state, **kwargs
+        n_components=n_clusters,
+        algorithm="parallel",
+        whiten="unit-variance",
+        fun="exp",
+        random_state=random_state,
+        **kwargs,
     )
 
     ica = ica.fit(data)

--- a/tests/tests_microstates.py
+++ b/tests/tests_microstates.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 import neurokit2 as nk
 
@@ -27,3 +28,54 @@ def test_microstates_peaks():
     peaks_frederic = locmax(gfp)
 
     assert all(elem in peaks_frederic for elem in peaks_nk)  # only works when distance_between = 0.01
+
+
+def test_microstates_peaks_training_selection():
+    eeg = np.random.RandomState(42).normal(size=(4, 20))
+
+    np.testing.assert_array_equal(nk.microstates_peaks(eeg, gfp="all"), np.arange(20))
+    np.testing.assert_array_equal(nk.microstates_peaks(eeg, gfp=5), [0, 4, 8, 12, 16])
+
+    gfp = np.zeros(20)
+    gfp[[7, 15]] = 1
+    np.testing.assert_array_equal(nk.microstates_peaks(eeg, gfp=gfp, sampling_rate=100), [7, 15])
+
+
+def test_microstates_clean_input_shapes_and_standardization():
+    eeg = np.arange(60, dtype=float).reshape(3, 20) + np.arange(3)[:, None] ** 2
+    data, indices, _, _ = nk.microstates_clean(pd.DataFrame(eeg), train="all", standardize_eeg=True)
+
+    assert data.shape == eeg.shape
+    np.testing.assert_array_equal(indices, np.arange(eeg.shape[1]))
+    np.testing.assert_allclose(np.mean(data, axis=1), 0, atol=1e-12)
+    np.testing.assert_allclose(np.std(data, axis=1, ddof=1), 1, atol=1e-12)
+
+
+def test_microstates_clean_mne_epochs():
+    import mne
+
+    rng = np.random.RandomState(42)
+    info = mne.create_info(["Fz", "Cz", "Pz", "Oz"], sfreq=100, ch_types="eeg")
+    epochs = mne.EpochsArray(rng.normal(size=(2, 4, 20)), info, verbose=False)
+
+    data, indices, gfp, returned_info = nk.microstates_clean(epochs, train="all", standardize_eeg=False)
+
+    assert data.shape == (4, 40)
+    np.testing.assert_array_equal(indices, np.arange(40))
+    assert gfp.shape == (40,)
+    assert returned_info is epochs.info
+
+
+def test_microstates_segment_keeps_clustering_kwargs_out_of_preprocessing():
+    eeg = np.random.RandomState(42).normal(size=(4, 30))
+    output = nk.microstates_segment(
+        eeg,
+        n_microstates=2,
+        train="all",
+        method="kmeans",
+        n_init=2,
+        random_state=42,
+    )
+
+    assert output["Sequence"].shape == (eeg.shape[1],)
+    assert output["Info_algorithm"]["sklearn_model"].n_init == 2

--- a/tests/tests_microstates.py
+++ b/tests/tests_microstates.py
@@ -2,6 +2,8 @@ import numpy as np
 import pandas as pd
 
 import neurokit2 as nk
+from neurokit2.microstates.microstates_segment import _microstates_segment_runsegmentation
+from neurokit2.stats.cluster_quality import _cluster_quality_gev
 
 
 # =============================================================================
@@ -65,6 +67,9 @@ def test_microstates_clean_mne_epochs():
     assert gfp.shape == (40,)
     assert returned_info is epochs.info
 
+    output = nk.microstates_segment(epochs, n_microstates=2, train="all", n_runs=2, random_state=42)
+    assert output["Sequence"].shape == (40,)
+
 
 def test_microstates_segment_keeps_clustering_kwargs_out_of_preprocessing():
     eeg = np.random.RandomState(42).normal(size=(4, 30))
@@ -79,3 +84,68 @@ def test_microstates_segment_keeps_clustering_kwargs_out_of_preprocessing():
 
     assert output["Sequence"].shape == (eeg.shape[1],)
     assert output["Info_algorithm"]["sklearn_model"].n_init == 2
+
+
+def test_microstates_classify_preserves_map_sequence_correspondence():
+    microstates = np.array(
+        [
+            [-0.403, 1.222, 0.208, 0.977, 0.356],
+            [0.707, 0.011, 1.786, 0.127, 0.402],
+            [1.883, -1.348, -1.270, 0.969, -1.173],
+        ]
+    )
+    segmentation = np.array([0, 1, 2])
+
+    classified, reordered, order = nk.microstates_classify(segmentation, microstates, return_order=True)
+
+    np.testing.assert_array_equal(order, [1, 2, 0])
+    np.testing.assert_array_equal(classified, [2, 0, 1])
+    for old_label, new_label in zip(segmentation, classified):
+        np.testing.assert_allclose(microstates[old_label], reordered[new_label])
+
+
+def test_microstates_segmentation_cv_gev_order_and_map_scale():
+    rng = np.random.RandomState(42)
+    eeg = rng.normal(size=(5, 50))
+    output = nk.microstates_segment(
+        eeg,
+        n_microstates=3,
+        train="all",
+        criterion="cv",
+        n_runs=2,
+        random_state=42,
+    )
+
+    assert isinstance(output["Info_algorithm"], dict)
+    _, expected_gev = _cluster_quality_gev(
+        eeg.T,
+        output["Microstates"],
+        output["Sequence"],
+        sd=output["GFP"],
+        n_clusters=3,
+    )
+    np.testing.assert_allclose(output["GEV_per_microstate"], expected_gev)
+
+    maps = rng.normal(size=(3, 5))
+    scaled_maps = maps * np.array([1, 10, 100])[:, None]
+    sequence, _, _, _ = _microstates_segment_runsegmentation(eeg, maps, output["GFP"], n_microstates=3)
+    scaled_sequence, _, _, _ = _microstates_segment_runsegmentation(
+        eeg, scaled_maps, output["GFP"], n_microstates=3
+    )
+    np.testing.assert_array_equal(sequence, scaled_sequence)
+
+
+def test_microstates_segment_documented_clustering_methods():
+    eeg = np.random.RandomState(42).normal(size=(6, 40))
+
+    for method in ["pca", "ica", "aahc"]:
+        output = nk.microstates_segment(
+            eeg,
+            n_microstates=2,
+            train="all",
+            method=method,
+            random_state=42,
+        )
+        assert output["Microstates"].shape == (2, eeg.shape[0])
+        assert output["Sequence"].shape == (eeg.shape[1],)
+        assert np.isfinite(output["GEV"])

--- a/tests/tests_microstates.py
+++ b/tests/tests_microstates.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 import neurokit2 as nk
 from neurokit2.microstates.microstates_segment import _microstates_segment_runsegmentation
+from neurokit2.microstates.microstates_static import _microstates_lifetime
 from neurokit2.stats.cluster_quality import _cluster_quality_gev
 
 
@@ -149,3 +150,10 @@ def test_microstates_segment_documented_clustering_methods():
         assert output["Microstates"].shape == (2, eeg.shape[0])
         assert output["Sequence"].shape == (eeg.shape[1],)
         assert np.isfinite(output["GEV"])
+
+
+def test_microstates_lifetime_counts_first_run_once():
+    _, lifetimes = _microstates_lifetime(np.array([0, 0, 1]), out={})
+
+    np.testing.assert_array_equal(lifetimes[0], [0, 1])
+    np.testing.assert_array_equal(lifetimes[1], [1])

--- a/tests/tests_microstates.py
+++ b/tests/tests_microstates.py
@@ -130,9 +130,7 @@ def test_microstates_segmentation_cv_gev_order_and_map_scale():
     maps = rng.normal(size=(3, 5))
     scaled_maps = maps * np.array([1, 10, 100])[:, None]
     sequence, _, _, _ = _microstates_segment_runsegmentation(eeg, maps, output["GFP"], n_microstates=3)
-    scaled_sequence, _, _, _ = _microstates_segment_runsegmentation(
-        eeg, scaled_maps, output["GFP"], n_microstates=3
-    )
+    scaled_sequence, _, _, _ = _microstates_segment_runsegmentation(eeg, scaled_maps, output["GFP"], n_microstates=3)
     np.testing.assert_array_equal(sequence, scaled_sequence)
 
 

--- a/tests/tests_stats.py
+++ b/tests/tests_stats.py
@@ -97,6 +97,18 @@ def test_kmeans():
     assert np.allclose(res[1][np.lexsort(res[1].T)], centres[np.lexsort(centres.T)])
 
 
+def test_cluster_microstates_method_routing():
+    rng = np.random.RandomState(42)
+    data = rng.normal(size=(20, 4))
+
+    _, _, info = nk.cluster(data, method="ica", n_clusters=2, random_state=42)
+    assert info["clustering_function"].func.__name__ == "_cluster_ica"
+
+    _, clusters, info = nk.cluster(data, method="aahc", n_clusters=2, random_state=42)
+    assert clusters.shape == (2, data.shape[1])
+    assert info["clustering_function"].func.__name__ == "_cluster_aahc"
+
+
 def test_cor():
     # pearson
     wiki_example_x = np.array([1, 2, 3, 5, 8])


### PR DESCRIPTION
# Description

  First, I would like to express my sincere appreciation for the work that has gone into NeuroKit2. It is an extremely valuable open-source project, and its broad collection of neurophysiological processing tools provides substantial value to the scientific community.

  While reviewing the microstate implementation, I identified several issues that could materially alter clustering, segmentation, and derived microstate statistics. Since these outputs may be used directly in scientific analyses and publications, the affected behavior had a high likelihood of introducing substantial
  bias into academic results without necessarily raising an explicit error.

  The main issues addressed by this PR are:

  - ICA was silently routed to the PCA implementation.
  - The documented `aahc` method did not reach the AAHC backend.
  - `train="all"` generated indices from the number of channels instead of the number of timepoints.
  - Precomputed GFP values supplied to `microstates_peaks()` were ignored.
  - Non-GFP training modes unnecessarily required a sampling rate.
  - Clustering keyword arguments leaked into EEG preprocessing functions.
  - EEG standardization was performed across channels rather than across time.
  - MNE Epochs inputs failed despite being documented as supported.
  - Microstate labels were incorrectly remapped after map reordering.
  - `GEV_per_microstate` was not reordered together with the maps.
  - The `criterion="cv"` path failed with a `TypeError`.
  - Backfitting was affected by arbitrary differences in microstate-map magnitude.
  - The first microstate lifetime was overcounted by one sample.
  - The ICA implementation used a FastICA argument that is invalid in current scikit-learn versions.

  # Proposed Changes

  ## Clustering backend routing

  The ICA aliases now call `_cluster_ica()` rather than `_cluster_pca()`.

  The documented `aahc` method is now recognized as an alias for `_cluster_aahc()`, alongside the existing `aahc_frederic` and `aahc_eegmicrostates` aliases.

  FastICA now uses `whiten="unit-variance"` for compatibility with current scikit-learn versions.

  Regression tests inspect the selected clustering function to ensure that ICA and AAHC reach their intended implementations.

  ## Training timepoint selection

  For EEG data shaped `(channels, timepoints)`, `train="all"` now returns:

  ```python
  np.arange(eeg.shape[1])
```
  The previous implementation used len(eeg), which represents the number of channels and therefore selected only the first n_channels timepoints.

  Numeric and "all" training modes no longer require sampling_rate, because no time-based GFP peak distance is calculated in these modes.

  Numeric training selections are validated to ensure that the requested number of samples is valid and does not exceed the available timepoints.

  ## GFP handling

  A precomputed GFP vector supplied to microstates_peaks() is now used directly instead of being silently discarded and recomputed.

  Precomputed GFP input is validated to ensure that it is one-dimensional and contains exactly one value per EEG timepoint.

  The GFP calculated by microstates_clean() is also reused for peak detection, ensuring consistency between the returned GFP and the GFP used to select training samples.

  ## Input preprocessing

  DataFrame input is converted into a consistent NumPy representation.

  MNE Epochs data, originally shaped (epochs, channels, timepoints), is converted into (channels, concatenated_timepoints). Epochs are concatenated in trial order while preserving the channel dimension and MNE channel information.

  The same Epochs conversion is applied in microstates_findnumber().

  EEG standardization is now performed independently for each channel across time, matching the documented behavior.

  Clustering-specific keyword arguments such as n_init are no longer passed to standardize(), eeg_gfp(), or microstates_peaks().

  ## Classification and output consistency

  microstates_classify() now uses the inverse permutation when relabeling the segmentation sequence.

  This ensures that, after reordering, every value in Sequence still refers to the correct row in Microstates.

  An optional return_order argument exposes the applied map permutation for internal consumers while preserving the existing default two-value return signature.

  GEV_per_microstate is reordered using the same permutation, keeping Sequence, Microstates, and per-state GEV values aligned.

  ## Segmentation and backfitting

  The criterion="cv" path now stores current_info correctly. The previous info -= current_info statement attempted to subtract a dictionary from None and failed during the first selected run.

  The criterion value and n_runs are now explicitly validated.

  Whole-recording backfitting now centers each topographic map and normalizes it to unit norm before calculating activation.

  This makes assignments invariant to arbitrary scaling of individual maps. This is particularly important for KMeans, PCA, and ICA maps, whose raw magnitudes are not inherently comparable.

  Polarity-independent assignment is preserved by selecting the largest absolute activation.

  ## Lifetime statistics

  The lifetime calculation now starts iteration from the second sample because the first state is already represented by the initial tau = 1.

  For example, [0, 0, 1] now correctly reports a two-sample lifetime for state 0 rather than three samples.

  ## Tests

  Regression coverage was added for:

  - ICA and AAHC backend routing.
  - All-timepoint and numeric training selection.
  - Precomputed GFP handling.
  - DataFrame input.
  - MNE Epochs preprocessing and end-to-end segmentation.
  - Per-channel temporal standardization.
  - Isolation of clustering keyword arguments.
  - Non-self-inverse classification permutations.
  - Sequence-to-map correspondence.
  - Per-state GEV ordering.
  - CV-based run selection.
  - Map-scale-invariant backfitting.
  - Documented PCA, ICA, and AAHC segmentation methods.
  - First-run lifetime counting.

  The targeted test results are:

  tests/tests_microstates.py: 9 passed
  tests/tests_stats.py:       7 passed
  Total:                     16 passed

  All modified files pass Ruff lint and Ruff format checks.

  # Checklist

  Here are some things to check before creating the PR. If you encounter any issues, do let us know :)

  - [x] I have read the [CONTRIBUTING](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) (https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#structure-and-code) file.
  - [x] My PR is targeted at the dev branch (and not towards the master branch).
  - [x] I ran the [CODE CHECKS](https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) (https://github.com/neuropsychology/NeuroKit/blob/master/.github/CONTRIBUTING.rst#run-code-checks) on the files I added or modified and fixed the errors.
  - [ ] I have added the newly added features to News.rst (if applicable).